### PR TITLE
Add dictionary engine for en-en

### DIFF
--- a/addon/chrome/content/preferences.xul
+++ b/addon/chrome/content/preferences.xul
@@ -104,6 +104,7 @@
                       <menupopup>
                         <menuitem label="&zotero.__addonRef__.pref.api.dictSource.youdaodict;" value="youdaodict" />
                         <menuitem label="&zotero.__addonRef__.pref.api.dictSource.bingdict;" value="bingdict" />
+                        <menuitem label="&zotero.__addonRef__.pref.api.dictSource.freedictionaryapi;" value="freedictionaryapi" />
                       </menupopup>
                     </menulist>
                     <label value="&zotero.__addonRef__.pref.api.secret.label;" />

--- a/addon/chrome/locale/en-US/overlay.dtd
+++ b/addon/chrome/locale/en-US/overlay.dtd
@@ -27,6 +27,7 @@
 <!ENTITY zotero.__addonRef__.pref.api.dictSource.label "Dictionary Engine">
 <!ENTITY zotero.__addonRef__.pref.api.dictSource.youdaodict "Youdao Dict(en↔zh)">
 <!ENTITY zotero.__addonRef__.pref.api.dictSource.bingdict "Bing Dict(en↔zh)">
+<!ENTITY zotero.__addonRef__.pref.api.dictSource.freedictionaryapi "FreeDictionaryAPI(en↔en)">
 
 <!ENTITY zotero.__addonRef__.pref.api.sourceLanguage.label "Translate From">
 <!ENTITY zotero.__addonRef__.pref.api.targetLanguage.label "To">

--- a/addon/chrome/locale/zh-CN/overlay.dtd
+++ b/addon/chrome/locale/zh-CN/overlay.dtd
@@ -27,6 +27,7 @@
 <!ENTITY zotero.__addonRef__.pref.api.dictSource.label "字典引擎">
 <!ENTITY zotero.__addonRef__.pref.api.dictSource.youdaodict "有道词典(en↔zh)">
 <!ENTITY zotero.__addonRef__.pref.api.dictSource.bingdict "必应词典(en↔zh)">
+<!ENTITY zotero.__addonRef__.pref.api.dictSource.freedictionaryapi "FreeDictionaryAPI(en↔en)">
 
 <!ENTITY zotero.__addonRef__.pref.api.sourceLanguage.label "从">
 <!ENTITY zotero.__addonRef__.pref.api.targetLanguage.label "翻译到">

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,7 @@ class TransConfig extends TransBase {
       "tencent",
       "youdaodict",
       "bingdict",
+      "freedictionaryapi"
     ];
     this.sourcesName = {
       googleapi: "Google(API)",
@@ -44,6 +45,7 @@ class TransConfig extends TransBase {
       tencent: "Tencent*",
       youdaodict: "Youdao Dict",
       bingdict: "Bing Dict",
+      freedictionaryapi: "FreeDictionaryAPI"
     };
     this.defaultSourceLanguage = "en-US";
     this.defaultTargetLanguage = "zh-CN";
@@ -65,6 +67,7 @@ class TransConfig extends TransBase {
         "secretId#SecretKey#Region(default ap-shanghai)#ProjectId(default 0)",
       youdaodict: "",
       bingdict: "",
+      freedictionaryapi: ""
     };
     this.LangCultureNames = [
       { LangCultureName: "af-ZA", DisplayName: "Afrikaans - South Africa" },

--- a/src/dict/freedictionaryapi.ts
+++ b/src/dict/freedictionaryapi.ts
@@ -33,7 +33,7 @@ async function freedictionaryapi(text: string = undefined) {
           let entry = definition.definition
 
           if (definition.example) {
-            entry += '\n"' + definition.example
+            entry += '\n"' + definition.example + '"'
           }
 
           definitionCollection.push(entry);

--- a/src/dict/freedictionaryapi.ts
+++ b/src/dict/freedictionaryapi.ts
@@ -1,0 +1,47 @@
+async function freedictionaryapi(text: string = undefined) {
+  let args = this.getArgs("freedictionaryapi", text);
+
+  return await this.requestTranslate(
+    async () => {
+      return await Zotero.HTTP.request(
+        "GET",
+        `https://api.dictionaryapi.dev/api/v2/entries/en/${args.text}`,
+        {
+          headers: {
+            "Accept": "application/json"
+          },
+          responseType: "json"
+        }
+      );
+    },
+    (xhr) => {
+      if (xhr.status == 404) {
+        return "Definition not found"
+      }
+
+      let meanings = xhr.response[0].meanings
+
+      let tgt = ""
+
+      for (let i = 0; i < meanings.length; i++) {
+        let definitions = meanings[i].definitions
+
+        for (let j = 0; j < definitions.length; j++) {
+          let def = definitions[j]
+
+          tgt += def.definition
+
+          if (def.example) {
+            tgt += "\n" + '"' + def.example + '"' + "\n\n"
+          }
+        }
+      }
+
+      Zotero.debug(tgt);
+      if (!text) Zotero.ZoteroPDFTranslate._translatedText = tgt;
+      return tgt;
+    }
+  );
+}
+
+export { freedictionaryapi };

--- a/src/dict/freedictionaryapi.ts
+++ b/src/dict/freedictionaryapi.ts
@@ -22,20 +22,25 @@ async function freedictionaryapi(text: string = undefined) {
       let meanings = xhr.response[0].meanings
 
       let tgt = ""
+      let definitionCollection = []
 
       for (let i = 0; i < meanings.length; i++) {
         let definitions = meanings[i].definitions
 
         for (let j = 0; j < definitions.length; j++) {
-          let def = definitions[j]
+          let definition = definitions[j]
 
-          tgt += def.definition
+          let entry = definition.definition
 
-          if (def.example) {
-            tgt += "\n" + '"' + def.example + '"' + "\n\n"
+          if (definition.example) {
+            entry += '\n"' + definition.example
           }
+
+          definitionCollection.push(entry);
         }
       }
+
+      tgt = definitionCollection.join("\n\n");
 
       Zotero.debug(tgt);
       if (!text) Zotero.ZoteroPDFTranslate._translatedText = tgt;

--- a/src/events.ts
+++ b/src/events.ts
@@ -581,11 +581,6 @@ class TransEvents extends TransBase {
       }
     }
 
-    if (!dictSource || !validSource) {
-      dictSource = "youdaodict";
-      Zotero.Prefs.set("ZoteroPDFTranslate.dictSource", dictSource);
-    }
-
     let langs = this._PDFTranslate.translate.LangCultureNames.map(
       (e) => e.LangCultureName
     );
@@ -612,6 +607,15 @@ class TransEvents extends TransBase {
     if (!targetLanguage || !validTL) {
       targetLanguage = Services.locale.getRequestedLocale();
       Zotero.Prefs.set("ZoteroPDFTranslate.targetLanguage", targetLanguage);
+    }
+
+    if (!dictSource || !validSource) {
+      if (targetLanguage.startsWith("en")){
+        dictSource = "freedictionaryapi";
+      } else {
+        dictSource = "youdaodict";
+      }
+      Zotero.Prefs.set("ZoteroPDFTranslate.dictSource", dictSource);
     }
 
     let secretObj = Zotero.Prefs.get("ZoteroPDFTranslate.secretObj");

--- a/src/events.ts
+++ b/src/events.ts
@@ -610,7 +610,7 @@ class TransEvents extends TransBase {
     }
 
     if (!dictSource || !validSource) {
-      if (targetLanguage.startsWith("en")){
+      if (sourceLanguage.startsWith("en") && targetLanguage.startsWith("en")) {
         dictSource = "freedictionaryapi";
       } else {
         dictSource = "youdaodict";

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -475,7 +475,7 @@ class TransEngine extends TransConfig {
     let retry = false;
     Zotero.debug(args);
     if (!engine) {
-      // Only Eng-Chn translation support word definition now
+      // Only Eng-Chn and Eng-Eng translation support word definition now
       if (
         Zotero.Prefs.get("ZoteroPDFTranslate.enableDict") &&
         args.text.trim().split(/[^a-z,A-Z]+/).length == 1 &&

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -11,6 +11,7 @@ import { youdao } from "./translate/youdao";
 import { youdaozhiyun } from "./translate/youdaozhiyun";
 import { youdaodict } from "./dict/youdaodict";
 import { bingdict } from "./dict/bingdict";
+import { freedictionaryapi } from "./dict/freedictionaryapi";
 
 class TransEngine extends TransConfig {
   _translateTime: number;
@@ -35,6 +36,7 @@ class TransEngine extends TransConfig {
   youdaozhiyun: Function;
   youdaodict: Function;
   bingdict: Function;
+  freedictionaryapi: Function;
 
   constructor(parent: PDFTranslate) {
     super(parent);
@@ -61,6 +63,7 @@ class TransEngine extends TransConfig {
     this.youdaozhiyun = youdaozhiyun;
     this.youdaodict = youdaodict;
     this.bingdict = bingdict;
+    this.freedictionaryapi = freedictionaryapi;
   }
 
   async callTranslate(text: string = "", disableCache: boolean = true) {
@@ -478,7 +481,8 @@ class TransEngine extends TransConfig {
         args.text.trim().split(/[^a-z,A-Z]+/).length == 1 &&
         // TODO: For all languages
         ((args.sl.indexOf("en") != -1 && args.tl.indexOf("zh") != -1) ||
-          (args.sl.indexOf("zh") != -1 && args.tl.indexOf("en") != -1))
+          (args.sl.indexOf("zh") != -1 && args.tl.indexOf("en") != -1) ||
+          (args.sl.indexOf("en") != -1 && args.tl.indexOf("en") != -1 && Zotero.Prefs.get("ZoteroPDFTranslate.dictSource") == "freedictionaryapi"))
       ) {
         engine = Zotero.Prefs.get("ZoteroPDFTranslate.dictSource");
         retry = true;


### PR DESCRIPTION
Add dictionary engine for en-en

Dictionary is useful for English when reading more complex texts. This PR adds dictionary from "Free Dictionary API".