### PR TITLE
New feat: Add mod key optine for auto translate

### DIFF
--- a/addon/chrome/content/preferences.xul
+++ b/addon/chrome/content/preferences.xul
@@ -60,8 +60,8 @@
                       <label value="&zotero.__addonRef__.pref.basic.enableAuto.label;" />
                     </column>
                     <column orient="horizontal">
-                      <checkbox id="zotero-prefpane-__addonRef__-settings-enable-mod-key" preference="pref-__addonRef__-enable-mod-key" />
-                      <label value="&zotero.__addonRef__.pref.basic.enableModKey.label;" oncommand="Zotero.ZoteroPDFTranslate.prefs.updateModKeySettings();" />
+                      <checkbox id="zotero-prefpane-__addonRef__-settings-enable-mod-key" preference="pref-__addonRef__-enable-mod-key" oncommand="Zotero.ZoteroPDFTranslate.prefs.updateModKeySettings();" />
+                      <label value="&zotero.__addonRef__.pref.basic.enableModKey.label;" />
                     </column>
                     <column orient="horizontal">
                       <radiogroup orient="horizontal" oncommand="Zotero.ZoteroPDFTranslate.prefs.updateModKeySettings();" id="zotero-prefpane-__addonRef__-settings-mod-key" preference="pref-__addonRef__-mod-key">

--- a/addon/chrome/content/preferences.xul
+++ b/addon/chrome/content/preferences.xul
@@ -56,15 +56,15 @@
                 <row>
                   <columns>
                     <column orient="horizontal">
-                      <checkbox id="zotero-prefpane-__addonRef__-settings-enable-auto" preference="pref-__addonRef__-enable-auto" />
+                      <checkbox id="zotero-prefpane-__addonRef__-settings-enable-auto" preference="pref-__addonRef__-enable-auto" oncommand="Zotero.ZoteroPDFTranslate.prefs.updateModKeySettings();" />
                       <label value="&zotero.__addonRef__.pref.basic.enableAuto.label;" />
                     </column>
                     <column orient="horizontal">
-                      <checkbox oncommand="Zotero.ZoteroPDFTranslate.prefs.updateModKeySettings();" id="zotero-prefpane-__addonRef__-settings-enable-mod-key" preference="pref-__addonRef__-enable-mod-key" />
-                      <label value="&zotero.__addonRef__.pref.basic.enableModKey.label;" />
+                      <checkbox id="zotero-prefpane-__addonRef__-settings-enable-mod-key" preference="pref-__addonRef__-enable-mod-key" />
+                      <label value="&zotero.__addonRef__.pref.basic.enableModKey.label;" oncommand="Zotero.ZoteroPDFTranslate.prefs.updateModKeySettings();" />
                     </column>
                     <column orient="horizontal">
-                      <radiogroup orient="horizontal" id="zotero-prefpane-__addonRef__-settings-mod-key" preference="pref-__addonRef__-mod-key">
+                      <radiogroup orient="horizontal" oncommand="Zotero.ZoteroPDFTranslate.prefs.updateModKeySettings();" id="zotero-prefpane-__addonRef__-settings-mod-key" preference="pref-__addonRef__-mod-key">
                         <radio id="zotero-prefpane-__addonRef__-settings-mod-key-ctrl" label="&zotero.__addonRef__.pref.basic.modKeyCtrl.label;" value="ctrl" />
                         <radio id="zotero-prefpane-__addonRef__-settings-mod-key-shift" label="&zotero.__addonRef__.pref.basic.modKeyShift.label;" value="shift" />
                         <radio id="zotero-prefpane-__addonRef__-settings-mod-key-alt" label="&zotero.__addonRef__.pref.basic.modKeyAlt.label;" value="alt" />

--- a/addon/chrome/content/preferences.xul
+++ b/addon/chrome/content/preferences.xul
@@ -8,6 +8,8 @@
       <preferences id="zotero-preferences-__addonRef__">
         <preference id="pref-__addonRef__-enable" name="extensions.zotero.ZoteroPDFTranslate.enable" type="bool" />
         <preference id="pref-__addonRef__-enable-popup" name="extensions.zotero.ZoteroPDFTranslate.enablePopup" type="bool" />
+        <preference id="pref-__addonRef__-enable-mod-key" name="extensions.zotero.ZoteroPDFTranslate.enableModKey" type="bool" />
+        <preference id="pref-__addonRef__-mod-key" name="extensions.zotero.ZoteroPDFTranslate.modKey" type="string" />
         <preference id="pref-__addonRef__-enable-comment" name="extensions.zotero.ZoteroPDFTranslate.enableComment" type="bool" />
         <preference id="pref-__addonRef__-annotationTranslationPosition" name="extensions.zotero.ZoteroPDFTranslate.annotationTranslationPosition" type="string" />
         <preference id="pref-__addonRef__-enable-commentedit" name="extensions.zotero.ZoteroPDFTranslate.enableCommentEdit" type="bool" />
@@ -52,8 +54,23 @@
                   <label value="&zotero.__addonRef__.pref.basic.enable.label;" />
                 </row>
                 <row>
-                  <checkbox id="zotero-prefpane-__addonRef__-settings-enable-auto" preference="pref-__addonRef__-enable-auto" />
-                  <label value="&zotero.__addonRef__.pref.basic.enableAuto.label;" />
+                  <columns>
+                    <column orient="horizontal">
+                      <checkbox id="zotero-prefpane-__addonRef__-settings-enable-auto" preference="pref-__addonRef__-enable-auto" />
+                      <label value="&zotero.__addonRef__.pref.basic.enableAuto.label;" />
+                    </column>
+                    <column orient="horizontal">
+                      <checkbox oncommand="Zotero.ZoteroPDFTranslate.prefs.updateModKeySettings();" id="zotero-prefpane-__addonRef__-settings-enable-mod-key" preference="pref-__addonRef__-enable-mod-key" />
+                      <label value="&zotero.__addonRef__.pref.basic.enableModKey.label;" />
+                    </column>
+                    <column orient="horizontal">
+                      <radiogroup orient="horizontal" id="zotero-prefpane-__addonRef__-settings-mod-key" preference="pref-__addonRef__-mod-key">
+                        <radio id="zotero-prefpane-__addonRef__-settings-mod-key-ctrl" label="&zotero.__addonRef__.pref.basic.modKeyCtrl.label;" value="ctrl" />
+                        <radio id="zotero-prefpane-__addonRef__-settings-mod-key-shift" label="&zotero.__addonRef__.pref.basic.modKeyShift.label;" value="shift" />
+                        <radio id="zotero-prefpane-__addonRef__-settings-mod-key-alt" label="&zotero.__addonRef__.pref.basic.modKeyAlt.label;" value="alt" />
+                      </radiogroup>
+                    </column>
+                  </columns>
                 </row>
                 <row>
                   <checkbox id="zotero-prefpane-__addonRef__-settings-enable-dict" preference="pref-__addonRef__-enable-dict" />

--- a/addon/chrome/locale/en-US/overlay.dtd
+++ b/addon/chrome/locale/en-US/overlay.dtd
@@ -3,6 +3,10 @@
 <!ENTITY zotero.__addonRef__.pref.basic.caption.label "Functions">
 <!ENTITY zotero.__addonRef__.pref.basic.enable.label "Enable Translation">
 <!ENTITY zotero.__addonRef__.pref.basic.enableAuto.label "Automatic Translation">
+<!ENTITY zotero.__addonRef__.pref.basic.enableModKey.label "Enable Mod Key">
+<!ENTITY zotero.__addonRef__.pref.basic.modKeyCtrl.label "Ctrl">
+<!ENTITY zotero.__addonRef__.pref.basic.modKeyShift.label "Shift">
+<!ENTITY zotero.__addonRef__.pref.basic.modKeyAlt.label "Alt">
 <!ENTITY zotero.__addonRef__.pref.basic.enableDict.label "Enable Dictionary">
 <!ENTITY zotero.__addonRef__.pref.basic.enablePopup.label "Enable Popup">
 <!ENTITY zotero.__addonRef__.pref.basic.enableComment.label "Automatic Annotation Translation">

--- a/addon/chrome/locale/zh-CN/overlay.dtd
+++ b/addon/chrome/locale/zh-CN/overlay.dtd
@@ -3,6 +3,10 @@
 <!ENTITY zotero.__addonRef__.pref.basic.caption.label "功能">
 <!ENTITY zotero.__addonRef__.pref.basic.enable.label "启用PDF翻译">
 <!ENTITY zotero.__addonRef__.pref.basic.enableAuto.label "自动翻译">
+<!ENTITY zotero.__addonRef__.pref.basic.enableModKey.label "启用辅助键">
+<!ENTITY zotero.__addonRef__.pref.basic.modKeyCtrl.label "Ctrl">
+<!ENTITY zotero.__addonRef__.pref.basic.modKeyShift.label "Shift">
+<!ENTITY zotero.__addonRef__.pref.basic.modKeyAlt.label "Alt">
 <!ENTITY zotero.__addonRef__.pref.basic.enableDict.label "启用字典">
 <!ENTITY zotero.__addonRef__.pref.basic.enablePopup.label "启用弹窗">
 <!ENTITY zotero.__addonRef__.pref.basic.enableComment.label "自动翻译批注">

--- a/addon/defaults/preferences/defaults.js
+++ b/addon/defaults/preferences/defaults.js
@@ -1,6 +1,8 @@
 pref("extensions.zotero.ZoteroPDFTranslate.enable", true);
 pref("extensions.zotero.ZoteroPDFTranslate.enableAuto", true);
 pref("extensions.zotero.ZoteroPDFTranslate.enablePopup", true);
+pref("extensions.zotero.ZoteroPDFTranslate.enableModKey", false);
+pref("extensions.zotero.ZoteroPDFTranslate.modKey", "ctrl");
 pref("extensions.zotero.ZoteroPDFTranslate.enableComment", true);
 pref("extensions.zotero.ZoteroPDFTranslate.annotationTranslationPosition", "comment");
 pref("extensions.zotero.ZoteroPDFTranslate.enableCommentEdit", true);

--- a/src/events.ts
+++ b/src/events.ts
@@ -163,6 +163,27 @@ class TransEvents extends AddonBase {
     let enablePopup = Zotero.Prefs.get("ZoteroPDFTranslate.enablePopup");
     if (enablePopup) {
       if (enableAuto) {
+        let enableModKey = Zotero.Prefs.get("ZoteroPDFTranslate.enableModKey");
+        if (enableModKey) {
+          let isModKeyPressed = false;
+
+          let evt = (event as KeyboardEvent);
+          switch (Zotero.Prefs.get("ZoteroPDFTranslate.modKey")) {
+            case "ctrl":
+              isModKeyPressed = evt.ctrlKey;
+              break;
+            case "shift":
+              isModKeyPressed = evt.shiftKey;
+              break;
+            case "alt":
+              isModKeyPressed = evt.altKey;
+              break;
+          }
+
+          if (!isModKeyPressed)
+            return false;
+        }
+
         this._Addon.view.buildPopupPanel();
       } else {
         this._Addon.view.buildPopupButton();
@@ -301,9 +322,9 @@ class TransEvents extends AddonBase {
       }
       let newInnerHTML = show
         ? // Switch to origin titles
-          currentRow.getField("shortTitle")
+        currentRow.getField("shortTitle")
         : // Switch to translated titles
-          currentRow.getField("title");
+        currentRow.getField("title");
       let titleElement = rowElement.getElementsByClassName(
         "cell-text"
       )[0] as Element;
@@ -379,8 +400,8 @@ class TransEvents extends AddonBase {
         "pdf-translate-standalone",
         `chrome,extrachrome,menubar,resizable=yes,scrollbars,status,${
           Zotero.Prefs.get("ZoteroPDFTranslate.keepWindowTop")
-            ? ",alwaysRaised=yes"
-            : ""
+          ? ",alwaysRaised=yes"
+          : ""
         }`
       );
       this._Addon.view.standaloneWindow = win;

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -14,6 +14,7 @@ class TransPref extends AddonBase {
     this.buildLanguageSettings();
     this.updatePreviewPannel();
     this.updateAnnotationTranslationSettings();
+    this.updateModKeySettings();
     this.updateAddToNoteSettings();
   }
 
@@ -94,10 +95,10 @@ class TransPref extends AddonBase {
   updateModKeySettings() {
     Zotero.debug("ZoteroPDFTranslate: updateModKeySettings.");
     let enableAuto = this._window.document.getElementById(
-      "zotero-prefpane-zoteropdftranslate-settings-settings-enable-auto"
+      "zotero-prefpane-zoteropdftranslate-settings-enable-auto"
     ) as XUL.Checkbox;
     let enableModKey = this._window.document.getElementById(
-      "zotero-prefpane-zoteropdftranslate-settings-settings-enable-mod-key"
+      "zotero-prefpane-zoteropdftranslate-settings-enable-mod-key"
     ) as XUL.Checkbox;
     enableModKey.disabled = !enableAuto.checked;
 

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -91,8 +91,24 @@ class TransPref extends AddonBase {
       parseFloat(lineHeightText.value) < 0 ? "1" : lineHeightText.value;
   }
 
+  updateModKeySettings() {
+    Zotero.debug("ZoteroPDFTranslate: updateModKeySettings.");
+    let enableAuto = this._window.document.getElementById(
+      "zotero-prefpane-zoteropdftranslate-settings-settings-enable-auto"
+    ) as XUL.Checkbox;
+    let enableModKey = this._window.document.getElementById(
+      "zotero-prefpane-zoteropdftranslate-settings-settings-enable-mod-key"
+    ) as XUL.Checkbox;
+    enableModKey.disabled = !enableAuto.checked;
+
+    const modKey: XUL.Element = this._window.document.getElementById(
+      "zotero-prefpane-zoteropdftranslate-settings-mod-key"
+    );
+    modKey.disabled = !(enableAuto.checked && enableModKey.checked);
+  }
+
   updateAnnotationTranslationSettings() {
-    Zotero.debug("ZoteroPDFTranslate: updateannotationTranslationSettings.");
+    Zotero.debug("ZoteroPDFTranslate: updateAnnotationTranslationSettings.");
     let enableAnnotationTranslation = this._window.document.getElementById(
       "zotero-prefpane-zoteropdftranslate-settings-enable-comment"
     ) as XUL.Checkbox;


### PR DESCRIPTION
Mod key is a sub-optine of auto translate. Selected text will be translate unless you press the key.
I like to select text for no reason, and the popup keeps annoy me.
Therefore I add this optine to make popup show up at the right time.