### PR TITLE
refactor: remove `crypto-js` and extract crypto helper function to a single module

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,13 @@
   },
   "homepage": "https://github.com/windingwind/zotero-pdf-translate#readme",
   "dependencies": {
-    "compressing": "^1.5.1",
-    "crypto-js": "^4.1.1",
-    "esbuild": "^0.14.34",
-    "jsencrypt": "^3.3.1",
-    "replace-in-file": "^6.3.2"
+    "jsencrypt": "^3.3.1"
   },
   "devDependencies": {
-    "release-it": "^15.5.0",
-    "zotero-types": "^0.0.5"
+    "compressing": "^1.6.2",
+    "esbuild": "^0.16.9",
+    "release-it": "^15.5.1",
+    "replace-in-file": "^6.3.5",
+    "zotero-types": "^0.0.8"
   }
 }

--- a/src/translate/cnki.ts
+++ b/src/translate/cnki.ts
@@ -1,4 +1,4 @@
-const CryptoJS = require("crypto-js");
+import { aesEcbEncrypt, base64 } from './crypto';
 
 async function getToken(forceRefresh: boolean = false) {
   let token = "";
@@ -10,14 +10,13 @@ async function getToken(forceRefresh: boolean = false) {
     );
     if (
       !forceRefresh &&
-      tokenObj &&
-      tokenObj.token &&
+      tokenObj?.token &&
       new Date().getTime() - tokenObj.t < 300 * 1000
     ) {
       token = tokenObj.token;
       doRefresh = false;
     }
-  } catch (e) {}
+  } catch (e) { }
   if (doRefresh) {
     const xhr = await Zotero.HTTP.request(
       "GET",
@@ -40,13 +39,11 @@ async function getToken(forceRefresh: boolean = false) {
   return token;
 }
 
-function getWord(t) {
-  var n = "4e87183cfd3a45fe";
-  var e = { mode: CryptoJS.mode.ECB, padding: CryptoJS.pad.Pkcs7 },
-    i = CryptoJS.enc.Utf8.parse(n),
-    s = CryptoJS.AES.encrypt(t, i, e),
-    r = s.toString().replace(/\//g, "_");
-  return (r = r.replace(/\+/g, "-")), r;
+async function getWord(text: string) {
+  const encrtypted = await aesEcbEncrypt(text, "4e87183cfd3a45fe");
+  const base64str = base64(encrtypted);
+  return base64str.replace(/\//g, "_")
+    .replace(/\+/g, "-");
 }
 
 async function cnki(text: string = undefined, retry: boolean = true) {
@@ -70,7 +67,7 @@ async function cnki(text: string = undefined, retry: boolean = true) {
             Token: await getToken(),
           },
           body: JSON.stringify({
-            words: getWord(args.text),
+            words: await getWord(args.text),
             translateType: null,
           }),
           responseType: "json",

--- a/src/translate/crypto.ts
+++ b/src/translate/crypto.ts
@@ -1,0 +1,77 @@
+function base64(buffer: ArrayBuffer) {
+  const str = String.fromCharCode(...new Uint8Array(buffer));
+  return btoa(str);
+}
+
+function hex(buffer: ArrayBuffer) {
+  const hashArray = Array.from(new Uint8Array(buffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function hmacSha1Digest(stringToSign: string, secretKey: string) {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey('raw', enc.encode(secretKey), {
+    name: 'HMAC',
+    hash: 'SHA-1'
+  }, false, ['sign'])
+  return crypto.subtle.sign('HMAC', key, enc.encode(stringToSign))
+}
+
+async function hmacSha256Digest(stringToSign: string, secretKey: string) {
+  const enc = new TextEncoder()
+  const key = await crypto.subtle.importKey('raw', enc.encode(secretKey), {
+    name: 'HMAC',
+    hash: 'SHA-256'
+  }, false, ['sign'])
+  return crypto.subtle.sign('HMAC', key, enc.encode(stringToSign))
+}
+
+async function sha256Digest(message: string) {
+  const enc = new TextEncoder();
+  return crypto.subtle.digest('SHA-256', enc.encode(message));
+}
+
+function pkcs7Pad(block: Uint8Array | Array<number>) {
+  const padding = 16 - block.length;
+  const pad = new Uint8Array(padding);
+  pad.fill(padding);
+  return new Uint8Array([...block, ...pad]);
+}
+
+// AES ECB encrypt, use CBC mode to simulate ECB mode
+async function aesEcbEncrypt(message: string, secret: string) {
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(secret), {
+    name: 'AES-CBC',
+  }, false, ['encrypt']);
+
+  const encodeStr = new TextEncoder().encode(message);
+  // split encoded string to 16 byte blocks
+  const blocks = [];
+  for (let i = 0; i < encodeStr.length; i += 16) {
+    const block = encodeStr.subarray(i, i + 16);
+    blocks.push(block);
+  }
+
+  if (!blocks.length || blocks[blocks.length - 1].length === 16) {
+    blocks.push(pkcs7Pad([])); // pad empty block
+  } else {
+    blocks[blocks.length - 1] = pkcs7Pad(blocks[blocks.length - 1]);
+  }
+
+  // encrypt each block, do not pad
+  const zeros = new Uint8Array(16);
+  const encryptedBlocks = await Promise.all(blocks.map(block => crypto.subtle.encrypt({
+    name: 'AES-CBC',
+    iv: block,
+  }, key, zeros)));
+  // concatenate encrypted blocks
+  const encrypted = new Uint8Array(encryptedBlocks.length * 16);
+  let offset = 0;
+  for (const block of encryptedBlocks) {
+    encrypted.set(new Uint8Array(block).subarray(0, 16), offset);
+    offset += 16;
+  }
+  return encrypted;
+}
+
+export { aesEcbEncrypt, base64, hex, hmacSha1Digest, hmacSha256Digest, sha256Digest };

--- a/src/translate/niutrans.ts
+++ b/src/translate/niutrans.ts
@@ -83,19 +83,19 @@ async function niutransLogin(username:string, password:string) {
   encrypt.setPublicKey(keyxhr.response.key);
   let encryptionPassword = encrypt.encrypt(password);
   encryptionPassword = encodeURIComponent(encryptionPassword);
-  let userLoginXhr = await loginApi(username,encryptionPassword)
+  const userLoginXhr = await loginApi(username,encryptionPassword)
   if(userLoginXhr && userLoginXhr.status && userLoginXhr.status === 200) {
     if(userLoginXhr.response.flag == 1) {
       let apikey = userLoginXhr.response.apikey;
       Zotero.Prefs.set("ZoteroPDFTranslate.niutransUsername", username);
       Zotero.Prefs.set("ZoteroPDFTranslate.niutransPassword", password);
       Zotero.Prefs.set("ZoteroPDFTranslate.niutransApikey", apikey);
-      let dicLibXhr = await getDictLibList(apikey)
-      let memoryLibXhr = await getMemoryLibList(apikey)
-      if(dicLibXhr && dicLibXhr.status && dicLibXhr.status === 200){
+      const dicLibXhr = await getDictLibList(apikey)
+      const memoryLibXhr = await getMemoryLibList(apikey)
+      if(dicLibXhr?.status === 200){
         Zotero.Prefs.set("ZoteroPDFTranslate.niutransDictLibList", JSON.stringify(dicLibXhr.response));
       }
-      if(memoryLibXhr && memoryLibXhr.status && memoryLibXhr.status === 200){
+      if(memoryLibXhr?.status === 200){
         Zotero.Prefs.set("ZoteroPDFTranslate.niutransMemoryLibList", JSON.stringify(memoryLibXhr.response));
       }
       loginFlag = true

--- a/src/translate/tencent.ts
+++ b/src/translate/tencent.ts
@@ -1,3 +1,5 @@
+import { base64, hmacSha1Digest } from "./crypto";
+
 async function tencent(text: string = undefined) {
   let args = this.getArgs("tencent", text);
   let params = args.secret.split("#");
@@ -19,18 +21,17 @@ async function tencent(text: string = undefined) {
       .replace(/%20/g, "+");
   }
 
-  let rawStr = `Action=TextTranslate&Language=zh-CN&Nonce=9744&ProjectId=${projectId}&Region=${region}&SecretId=${secretId}&Source=${
-    args.sl.split("-")[0]
-  }&SourceText=#$#&Target=${args.tl.split("-")[0]}&Timestamp=${new Date()
-    .getTime()
-    .toString()
-    .substring(0, 10)}&Version=2018-03-21`;
+  const rawStr = `Action=TextTranslate&Language=zh-CN&Nonce=9744&ProjectId=${projectId}&Region=${region}&SecretId=${secretId}&Source=${args.sl.split("-")[0]
+    }&SourceText=#$#&Target=${args.tl.split("-")[0]}&Timestamp=${new Date()
+      .getTime()
+      .toString()
+      .substring(0, 10)}&Version=2018-03-21`;
 
-  let sha1Str = encodeRFC5987ValueChars(
-    await hmacSha1Digest(
+  const sha1Str = encodeRFC5987ValueChars(
+    base64(await hmacSha1Digest(
       `POSTtmt.tencentcloudapi.com/?${rawStr.replace("#$#", args.text)}`,
       secretKey
-    )
+    ))
   );
 
   return await this.requestTranslate(
@@ -61,17 +62,6 @@ async function tencent(text: string = undefined) {
       return tgt;
     }
   );
-}
-
-async function hmacSha1Digest(stringToSign: string, secretKey: string) {
-	const enc = new TextEncoder()
-	const key = await crypto.subtle.importKey('raw', enc.encode(secretKey), {
-		name: 'HMAC',
-		hash: 'SHA-1'
-	}, false, ['sign'])
-	const signature = await crypto.subtle.sign('HMAC', key, enc.encode(stringToSign))
-	const signedString = String.fromCharCode(...new Uint8Array(signature))
-	return btoa(signedString)
 }
 
 export { tencent };

--- a/src/translate/youdao.ts
+++ b/src/translate/youdao.ts
@@ -28,4 +28,5 @@ async function youdao(text: string = undefined) {
     }
   );
 }
+
 export { youdao };

--- a/src/translate/youdaozhiyun.ts
+++ b/src/translate/youdaozhiyun.ts
@@ -1,3 +1,5 @@
+import {hex, sha256Digest} from './crypto';
+
 async function youdaozhiyun(text: string = undefined) {
   const args = this.getArgs("youdaozhiyun", text);
 
@@ -24,7 +26,7 @@ async function youdaozhiyun(text: string = undefined) {
   const to = args.tl;
   const str1 = appid + truncate(query) + salt + curtime + key;
 
-  const sign = await sha256Digest(str1);
+  const sign = hex(await sha256Digest(str1));
   return await this.requestTranslate(
     async () => {
       return await Zotero.HTTP.request(
@@ -51,13 +53,6 @@ async function youdaozhiyun(text: string = undefined) {
       return tgt;
     }
   );
-}
-
-async function sha256Digest(message: string) {
-  const enc = new TextEncoder();
-  const hashBuffer = await crypto.subtle.digest('SHA-256', enc.encode(message));
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 export { youdaozhiyun };


### PR DESCRIPTION
I've use [AES CBC](https://developer.mozilla.org/zh-CN/docs/Web/API/SubtleCrypto/encrypt#aes-cbc_2) mode (which is supported by web crypto API) to simulate AES ECB (which is not supported). And now, we can remove package `crypto-js`.

build: move `compressing`, `esbuild`, and `replace-in-file` to devdependencies.

After refactoring, the size of `.xpi` file reduced to `62.9KB` (from `86KB`)

Note: I haven't tested [`xftrans`](https://www.xfyun.cn/services/xftrans). The logic just seems ok for me.
