### PR TITLE
fix bing phonetic

### DIFF
--- a/src/modules/services/bingdict.ts
+++ b/src/modules/services/bingdict.ts
@@ -25,7 +25,7 @@ export default <TranslateTaskProcessor>async function (data) {
     throw "Parse error";
   }
   let tgt = "";
-  for (let line of res.split("，").slice(1)) {
+  for (let line of res.split("，").slice(3)) {
     if (line.indexOf("网络释义") > -1) {
       tgt += line.slice(0, line.lastIndexOf("；"));
     } else {


### PR DESCRIPTION
Since the phonetic has already in tool-button, they should be excluded from the description. 
As far as I know, there is no longer needed to loop of the lines, I just keep the code there for robustness.
