### PR TITLE
Add：Translate sentence by sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Once you have the plugin installed simply, open any PDF in your collections.
 - Translate item abstract with right-click menu(v0.8.0). Thanks @iShareStuff
 - Standalone translation window available(v0.7.0). View & compare translations from multiply engines in one window!
   ![](imgs/standalone.png)
-- Dictionary for single word translation(v0.7.1). _Only for en2zh and en2en now_
+- Dictionary for single word translation(v0.7.1).
+- SentenceBySentence Translation(v1.1.0). After a translation, press `shift`+`P` and select `Translate Sentences`. _Only for en2zh and en2en now_. Thanks @MuiseDestiny
 
 ### Q&A
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "homepage": "https://github.com/windingwind/zotero-pdf-translate#readme",
   "dependencies": {
     "jsencrypt": "^3.3.1",
+    "sentence-extractor": "^1.0.7",
     "zotero-plugin-toolkit": "^2.0.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "homepage": "https://github.com/windingwind/zotero-pdf-translate#readme",
   "dependencies": {
     "jsencrypt": "^3.3.1",
-    "sentence-extractor": "^1.0.7",
     "zotero-plugin-toolkit": "^2.0.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,18 +40,18 @@
   "homepage": "https://github.com/windingwind/zotero-pdf-translate#readme",
   "dependencies": {
     "jsencrypt": "^3.3.1",
-    "zotero-plugin-toolkit": "^2.0.5"
+    "zotero-plugin-toolkit": "^2.0.6"
   },
   "devDependencies": {
-    "@types/node": "^18.11.17",
-    "compressing": "^1.6.3",
+    "@types/node": "^18.14.0",
+    "compressing": "^1.7.0",
     "concurrently": "^7.6.0",
     "cross-env": "^7.0.3",
-    "esbuild": "^0.17.4",
-    "minimist": "^1.2.7",
+    "esbuild": "^0.17.9",
+    "minimist": "^1.2.8",
     "release-it": "^15.6.0",
     "replace-in-file": "^6.3.5",
-    "typescript": "^4.9.4",
-    "zotero-types": "^1.0.10"
+    "typescript": "^4.9.5",
+    "zotero-types": "^1.0.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,18 +40,18 @@
   "homepage": "https://github.com/windingwind/zotero-pdf-translate#readme",
   "dependencies": {
     "jsencrypt": "^3.3.1",
-    "zotero-plugin-toolkit": "^2.0.6"
+    "zotero-plugin-toolkit": "^2.0.5"
   },
   "devDependencies": {
-    "@types/node": "^18.14.0",
-    "compressing": "^1.7.0",
+    "@types/node": "^18.11.17",
+    "compressing": "^1.6.3",
     "concurrently": "^7.6.0",
     "cross-env": "^7.0.3",
-    "esbuild": "^0.17.9",
-    "minimist": "^1.2.8",
+    "esbuild": "^0.17.4",
+    "minimist": "^1.2.7",
     "release-it": "^15.6.0",
     "replace-in-file": "^6.3.5",
-    "typescript": "^4.9.5",
-    "zotero-types": "^1.0.11"
+    "typescript": "^4.9.4",
+    "zotero-types": "^1.0.10"
   }
 }

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -124,7 +124,6 @@ export class ZToolkit extends BasicTool {
     this.ReaderTabPanel = new ReaderTabPanelManager(this);
     this.ReaderInstance = new ReaderInstanceManager(this);
     this.Prompt = new PromptManager(this);
-
     this.Dialog = DialogHelper;
     this.ProgressWindow = ProgressWindowHelper;
     this.ProgressWindow.setIconURI(

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -84,6 +84,7 @@ import { MenuManager } from "zotero-plugin-toolkit/dist/managers/menu";
 import { PreferencePaneManager } from "zotero-plugin-toolkit/dist/managers/preferencePane";
 import { ReaderTabPanelManager } from "zotero-plugin-toolkit/dist/managers/readerTabPanel";
 import { ReaderInstanceManager } from "zotero-plugin-toolkit/dist/managers/readerInstance";
+import { PromptManager } from "zotero-plugin-toolkit/dist/managers/prompt";
 import { ProgressWindowHelper } from "zotero-plugin-toolkit/dist/helpers/progressWindow";
 import { ClipboardHelper } from "zotero-plugin-toolkit/dist/helpers/clipboard";
 import { ReaderTool } from "zotero-plugin-toolkit/dist/tools/reader";
@@ -101,6 +102,7 @@ export class ZToolkit extends BasicTool {
   Menu: MenuManager;
   ItemTree: ItemTreeManager;
   ItemBox: ItemBoxManager;
+  Prompt: PromptManager;
   PreferencePane: PreferencePaneManager;
   ReaderTabPanel: ReaderTabPanelManager;
   ReaderInstance: ReaderInstanceManager;
@@ -121,6 +123,8 @@ export class ZToolkit extends BasicTool {
     this.PreferencePane = new PreferencePaneManager(this);
     this.ReaderTabPanel = new ReaderTabPanelManager(this);
     this.ReaderInstance = new ReaderInstanceManager(this);
+    this.Prompt = new PromptManager(this);
+
     this.Dialog = DialogHelper;
     this.ProgressWindow = ProgressWindowHelper;
     this.ProgressWindow.setIconURI(

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -31,6 +31,7 @@ import {
 import { registerShortcuts } from "./modules/shortcuts";
 import { config } from "../package.json";
 import { registerItemBoxExtraRows } from "./modules/itemBox";
+import { registerPrompt } from "./modules/prompt";
 
 async function onStartup() {
   await Promise.all([
@@ -51,6 +52,7 @@ async function onStartup() {
   await registerItemBoxExtraRows();
   registerTitleRenderer();
   registerShortcuts();
+  registerPrompt()
 }
 
 function onShutdown(): void {

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -34,7 +34,7 @@ export function registerPrompt() {
         let sentences: string[] = []
         let sentence = ""
         // https://www.npmjs.com/package/sentence-extractor?activeTab=explore
-        const abbrs = ["a.m.", "p.m.", "etc.", "vol.", "inc.", "jr.", "dr.", "tex.", "co.", "prof.", "rev.", "revd.", "hon.", "v.s.", "ie.",
+        const abbrs = ["a.m.", "p.m.", "etc.", "vol.", "inc.", "jr.", "dr.", "tex.", "co.", "prof.", "rev.", "revd.", "hon.", "v.s.", "i.e.", "ie.",
           "eg.", "e.g.", "al.", "st.", "ph.d.", "capt.", "mr.", "mrs.", "ms.", "fig."]
         let getWord = (i: number) => {
           let before, after;
@@ -51,9 +51,9 @@ export function registerPrompt() {
             return word == abbr
           })
         }
-        let isNumber = (i: number) => {
-          return i - 1 >= 0 && /\d/.test(text[i - 1]) && i + 1 < text.length && /\d/.test(text[i + 1])
-        }
+        // let isNumber = (i: number) => {
+        //   return i - 1 >= 0 && /\d/.test(text[i - 1]) && i + 1 < text.length && /\d/.test(text[i + 1])
+        // }
         let isPotentialAbbr = (i: number) => {
           const word = getWord(i)
           let parts = word.split(".").filter(i => i)
@@ -64,7 +64,7 @@ export function registerPrompt() {
           sentence += char
           if (dividers.indexOf(char) != -1) {
             if (char == ".") {
-              if (((isAbbr(i) || isPotentialAbbr(i)) && !/^\.\s[A-Z]/.test(text.slice(i))) || isNumber(i)) {
+              if ((i + 1< text.length && text[i+1] != " ") || ((isAbbr(i) || isPotentialAbbr(i)) && !/^\.\s[A-Z]/.test(text.slice(i)))) {
                 i += 1
                 continue
               }

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -40,7 +40,6 @@ export function registerPrompt() {
             // 2.33
             (/\d\.$/i.test(sentences[i]) && /^\d/i.test(sentences[i + 1]))
           ) {
-            console.log(sentences[i], "-", sentences[i + 1])
             sentences[i] = sentences[i] + sentences[i + 1]
             sentences.splice(i + 1, 1)
           } else {

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -25,7 +25,6 @@ export function registerPrompt() {
         // @ts-ignore
         prompt.exit()
       }
-      console.log(task)
       prompt.inputNode.placeholder = task.service
       const rawText = task.raw, resultText = task.result;
 
@@ -49,7 +48,6 @@ export function registerPrompt() {
           }
         }
         sentences = sentences.filter(s => s.length > 0)
-        console.log(sentences)
         for (let i = 0; i < sentences.length; i++) {
           console.log(sentences[i])
           node.appendChild(ztoolkit.UI.createElement(document, "span", {
@@ -169,7 +167,6 @@ export function registerPrompt() {
         document.removeEventListener('mouseup', mouseUpHandler);
       };
       resizer.addEventListener('mousedown', mouseDownHandler);
-      // resizer
       container.append(rawDiv, resizer, resultDiv)
     }
   }])

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -169,7 +169,6 @@ export function registerPrompt() {
           cursor: direction == "column" ? "ns-resize" : "ew-resize",
         },
       })
-      // 可调
       let y = 0, x = 0;
       let h = 0, w = 0;
       const rect = container.getBoundingClientRect();

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -124,38 +124,46 @@ export function registerPrompt() {
       const directions = ["row", "column"]
       const direction = directions[1]
       container.setAttribute("style", `
-          display: flex;
-          flex-direction: ${direction};
-          padding: .5em 1em;
-          margin-left: 0px;
-          width: 100%;
-          height: 25em;
-        `)
-      const props = {
-        styles: {
-          height: "100%",
-          width: "100%",
-          minWidth: "10em",
-          minHeight: "5em",
-          border: "1px solid #eee",
-          textAlign: "justify",
-          padding: ".5em",
-          fontSize: "1em",
-          lineHeight: "1.5em",
-          overflowY: "auto"
-        },
-      }
-      const rawDiv = ztoolkit.UI.createElement(document, "div", {
-        ...props,
-        classList: ["raw"]
+        display: flex;
+        flex-direction: ${direction};
+        padding: .5em 1em;
+        margin-left: 0px;
+        width: 100%;
+        height: 25em;
+      `)
+      const subContainers: HTMLDivElement[] = [];
+      [
+        ["raw", rawText, [".", "?", "!"]],
+        ["result", resultText, ["?", "!", "！", "。", "？"]]
+      ].forEach((args: any[]) => {        
+        let [className, text, dividers] = args;
+        const subContainer = ztoolkit.UI.createElement(document, "div", {
+          styles: {
+            padding: ".5em",
+            border: "1px solid #eee",
+            overflowY: "auto",
+            minWidth: "10em",
+            minHeight: "5em",
+            height: "100%",
+            width: "100%",
+            textAlign: "justify",
+          },
+          children: [
+            {
+              tag: "div",
+              classList: [className],
+              styles: {
+                fontSize: "1em",
+                lineHeight: "1.5em",
+                marginBottom: ".5em"
+              },
+            }
+          ]
+        });
+        addSentences(subContainer.querySelector(`.${className}`)!, text, dividers);
+        subContainers.push(subContainer);
       })
 
-      addSentences(rawDiv, rawText, [".", "?", "!"])
-      const resultDiv = ztoolkit.UI.createElement(document, "div", {
-        ...props,
-        classList: ["result"]
-      })
-      addSentences(resultDiv, resultText, ["?", "!", "！", "。", "？"])
       const size = 5
       const resizer = ztoolkit.UI.createElement(document, "div", {
         styles: {
@@ -204,7 +212,8 @@ export function registerPrompt() {
         document.removeEventListener('mouseup', mouseUpHandler);
       };
       resizer.addEventListener('mousedown', mouseDownHandler);
-      container.append(rawDiv, resizer, resultDiv)
+
+      container.append(subContainers[0], resizer, subContainers[1])
     }
   }])
 }

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -91,15 +91,14 @@ export function registerPrompt() {
       // TODO: prefs: direction
       const directions = ["row", "column"]
       const direction = directions[1]
-      // @ts-ignore
-      container.style = `
+      container.setAttribute("style", `
         display: flex;
         flex-direction: ${direction};
         padding: .5em 1em;
         margin-left: 0px;
         width: 100%;
         height: 25em;
-      `
+      `)
       const props = {
         styles: {
           height: "100%",

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -3,7 +3,7 @@ import { config } from "../../package.json";
 export function registerPrompt() {
   ztoolkit.Prompt.register([{
     name: "Translate Sentences",
-    label: "Translate",
+    label: config.addonName,
     when: () => {
       const selection = ztoolkit.Reader.getSelectedText(
         Zotero.Reader.getByTabID(Zotero_Tabs.selectedID)

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -37,23 +37,34 @@ export function registerPrompt() {
         // https://www.npmjs.com/package/sentence-extractor?activeTab=explore
         const abbrs = ["a.m.", "p.m.", "etc.", "vol.", "inc.", "jr.", "dr.", "tex.", "co.", "prof.", "rev.", "revd.", "hon.", "v.s.", "ie.",
           "eg.", "e.g.", "et al.", "st.", "ph.d.", "capt.", "mr.", "mrs.", "ms."]
+        let getWord = (i: number) => {
+          let before, after;
+          before = text.slice(0, i).match(/[\.a-zA-Z]+$/)
+          after = text.slice(i + 1).match(/^[\.a-zA-Z]+/)
+          let word = ([before, ["."], after].filter(i => i) as string[][])
+            .map((i: string[]) => i[0]).join("")
+          return word
+        }
         let isAbbr = (i: number) => {
+          const word = getWord(i)
           return abbrs.find((abbr: string) => {
-            return (
-              i >= abbr.length && text[i - abbr.length] == " " &&
-              text.slice(i - abbr.length + 1, i + 1).toLowerCase() == abbr.toLowerCase()
-            )
+            return word.toLowerCase() == abbr.toLowerCase()
           })
         }
         let isNumber = (i: number) => {
           return i - 1 >= 0 && /\d/.test(text[i - 1]) && i + 1 < text.length && /\d/.test(text[i + 1])
+        }
+        let isPotentialAbbr = (i: number) => {
+          const word = getWord(i)
+          let parts = word.split(".").filter(i => i)
+          return parts.length > 2 && parts.every(part => part.length <= 2)
         }
         while (i < text.length) {
           let char = text[i]
           sentence += char
           if (dividers.indexOf(char) != -1) {
             if (char == ".") {
-              if (isAbbr(i) || isNumber(i)) {
+              if (isAbbr(i) || isNumber(i) || isPotentialAbbr(i)) {
                 i += 1
                 continue
               }

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -3,44 +3,32 @@ import { config } from "../../package.json";
 export function registerPrompt() {
   ztoolkit.Prompt.register([{
     name: "Translate Sentences",
-    label: config.addonName,
+    label: config.addonInstance,
     when: () => {
       const selection = ztoolkit.Reader.getSelectedText(
         Zotero.Reader.getByTabID(Zotero_Tabs.selectedID)
       );
-      ztoolkit.log(selection)
-      return selection.length > 0
+      const sl = Zotero.Prefs.get("ZoteroPDFTranslate.sourceLanguage") as string
+      const tl = Zotero.Prefs.get("ZoteroPDFTranslate.targetLanguage") as string
+      return selection.length > 0 && Zotero?.PDFTranslate && sl.startsWith("en") && tl.startsWith("zh")
     },
-    callback: (prompt) => {
+    callback: async (prompt) => {
       const selection = ztoolkit.Reader.getSelectedText(
         Zotero.Reader.getByTabID(Zotero_Tabs.selectedID)
       );
-      const container = prompt.createCommandsContainer() as HTMLDivElement
-      container.style = `
-          padding: .5em;
-          display: flex;
-          flex-direction: row;
-          justify-content: space-between;
-        `
       const queue = Zotero.PDFTranslate.data.translate.queue
-      const task = queue.find((i: any) => i.raw == selection) || queue.slice(-1)[0]
+      let task = queue.find((task: any) => task.raw == selection && task.result.length > 0)
       if (!task) {
-        prompt.showTip("Task is Null.")
+        prompt.showTip("Loading...")
+        task = await Zotero.PDFTranslate.api.translate(selection)
+        Zotero.PDFTranslate.data.translate.queue.push(task)
+        // @ts-ignore
+        prompt.exit()
       }
+      console.log(task)
+      prompt.inputNode.placeholder = task.service
       const rawText = task.raw, resultText = task.result;
-      const props = {
-        styles: {
-          width: "49%",
-          height: "20em",
-          border: "1px solid #eee",
-          textAlign: "justify",
-          padding: ".5em",
-          fontSize: "1em",
-          lineHeight: "1.5em",
-          overflowY: "auto",
-        },
-      }
-      // TODO: prefs
+
       let addSentences = (node: HTMLElement, text: string, sep: string) => {
         let sentences = text.match(new RegExp(`.+?${sep}\\s*`, "g"))! as string[]
         let i = 0
@@ -82,26 +70,107 @@ export function registerPrompt() {
                   const parentNode = span.parentNode as HTMLDivElement
                   parentNode?.querySelectorAll("span").forEach(e => e.style.backgroundColor = "")
                   span.style.backgroundColor = hightlightColor
-                  const siblingNode = (parentNode?.previousSibling || parentNode?.nextSibling) as HTMLDivElement
+                  const siblingNode = (parentNode?.previousSibling?.previousSibling || parentNode?.nextSibling?.nextSibling) as HTMLDivElement
                   siblingNode?.querySelectorAll("span").forEach(e => e.style.backgroundColor = "");
                   const twinSpan = siblingNode.querySelector(`span[id=sentence-${i}]`) as HTMLSpanElement
                   twinSpan.style.backgroundColor = hightlightColor;
-                  siblingNode.scrollTo(0, twinSpan.offsetTop - siblingNode.offsetHeight * .5);
+                  if (direction == "column" && siblingNode.classList.contains("result")) {
+                    siblingNode.scrollTo(0, twinSpan.offsetTop - siblingNode.offsetHeight * .5 - parentNode.offsetHeight);
+                  } else {
+                    siblingNode.scrollTo(0, twinSpan.offsetTop - siblingNode.offsetHeight * .5);
+                  }
                 }
               }
             ]
           }))
         }
       }
+      const container = prompt.createCommandsContainer() as HTMLDivElement
+      // TODO: prefs: direction
+      const directions = ["row", "column"]
+      const direction = directions[1]
+      // @ts-ignore
+      container.style = `
+          display: flex;
+          flex-direction: ${direction};
+          padding: .5em 1em;
+          margin-left: 0px;
+          width: 100%;
+          height: 25em;
+        `
+      const props = {
+        styles: {
+          height: "100%",
+          width: "100%",
+          minWidth: "10em",
+          minHeight: "5em",
+          border: "1px solid #eee",
+          textAlign: "justify",
+          padding: ".5em",
+          fontSize: "1em",
+          lineHeight: "1.5em",
+          overflowY: "auto"
+        },
+      }
       const rawDiv = ztoolkit.UI.createElement(document, "div", {
-        ...props
+        ...props,
+        classList: ["raw"]
       })
       addSentences(rawDiv, rawText, "[\\.;]")
       const resultDiv = ztoolkit.UI.createElement(document, "div", {
         ...props,
+        classList: ["result"]
       })
       addSentences(resultDiv, resultText, "[。;；]")
-      container.append(rawDiv, resultDiv)
+      const size = 5
+      const resizer = ztoolkit.UI.createElement(document, "div", {
+        styles: {
+          height: (direction == "row" ? "100%" : `${size}px`),
+          width: (direction == "column" ? "100%" : `${size}px`),
+          backgroundColor: "#f0f0f0",
+          cursor: direction == "column" ? "ns-resize" : "ew-resize",
+        },
+      })
+      // 可调
+      let y = 0, x = 0;
+      let h = 0, w = 0;
+      const rect = container.getBoundingClientRect();
+      const H = rect.height;
+      const W = rect.width;
+      const mouseDownHandler = function (e: any) {
+        // hide
+        rawDiv.childNodes.forEach((e: any) => e.style.display = "none")
+        resultDiv.childNodes.forEach((e: any) => e.style.display = "none")
+        y = e.clientY;
+        x = e.clientX;
+        const rect = resultDiv.getBoundingClientRect()
+        h = rect.height;
+        w = rect.width;
+        document.addEventListener('mousemove', mouseMoveHandler);
+        document.addEventListener('mouseup', mouseUpHandler);
+      };
+      const mouseMoveHandler = function (e: any) {
+        const dy = e.clientY - y;
+        const dx = e.clientX - x;
+        if (direction == "column") {
+          resultDiv.style.height = `${h - dy}px`;
+          rawDiv.style.height = `${H - (h - dy) - size}px`;
+        }
+        if (direction == "row") {
+          resultDiv.style.width = `${w - dx}px`;
+          rawDiv.style.width = `${W - (w - dx) - size}px`;
+        }
+      };
+      const mouseUpHandler = function () {
+        // show
+        rawDiv.childNodes.forEach((e: any) => e.style.display = "")
+        resultDiv.childNodes.forEach((e: any) => e.style.display = "")
+        document.removeEventListener('mousemove', mouseMoveHandler);
+        document.removeEventListener('mouseup', mouseUpHandler);
+      };
+      resizer.addEventListener('mousedown', mouseDownHandler);
+      // resizer
+      container.append(rawDiv, resizer, resultDiv)
     }
   }])
 }

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -36,7 +36,7 @@ export function registerPrompt() {
         let sentence = ""
         // https://www.npmjs.com/package/sentence-extractor?activeTab=explore
         const abbrs = ["a.m.", "p.m.", "etc.", "vol.", "inc.", "jr.", "dr.", "tex.", "co.", "prof.", "rev.", "revd.", "hon.", "v.s.", "ie.",
-          "eg.", "e.g.", "et al.", "st.", "ph.d.", "capt.", "mr.", "mrs.", "ms."]
+          "eg.", "e.g.", "al.", "st.", "ph.d.", "capt.", "mr.", "mrs.", "ms.", "fig."]
         let getWord = (i: number) => {
           let before, after;
           before = text.slice(0, i).match(/[\.a-zA-Z]+$/)
@@ -46,9 +46,13 @@ export function registerPrompt() {
           return word
         }
         let isAbbr = (i: number) => {
-          const word = getWord(i)
+          const word = getWord(i).toLowerCase().replace(/\s+/g, " ")
           return abbrs.find((abbr: string) => {
-            return word.toLowerCase() == abbr.toLowerCase()
+            abbr = abbr.toLowerCase()
+            if (word.includes("al.")) {
+              console.log(word, abbr)
+            }
+            return word == abbr
           })
         }
         let isNumber = (i: number) => {
@@ -150,12 +154,12 @@ export function registerPrompt() {
         classList: ["raw"]
       })
 
-      addSentences(rawDiv, rawText, [".", ";", "?", "!"])
+      addSentences(rawDiv, rawText, [".", "?", "!"])
       const resultDiv = ztoolkit.UI.createElement(document, "div", {
         ...props,
         classList: ["result"]
       })
-      addSentences(resultDiv, resultText, [";", "?", "!", "！", "；", "。", "？"])
+      addSentences(resultDiv, resultText, ["?", "!", "！", "。", "？"])
       const size = 5
       const resizer = ztoolkit.UI.createElement(document, "div", {
         styles: {

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -29,7 +29,6 @@ export function registerPrompt() {
       }
       prompt.inputNode.placeholder = task.service
       const rawText = task.raw, resultText = task.result;
-
       let addSentences = (node: HTMLElement, text: string, dividers: string[]) => {
         let i = 0
         let sentences: string[] = []
@@ -49,9 +48,6 @@ export function registerPrompt() {
           const word = getWord(i).toLowerCase().replace(/\s+/g, " ")
           return abbrs.find((abbr: string) => {
             abbr = abbr.toLowerCase()
-            if (word.includes("al.")) {
-              console.log(word, abbr)
-            }
             return word == abbr
           })
         }
@@ -68,7 +64,7 @@ export function registerPrompt() {
           sentence += char
           if (dividers.indexOf(char) != -1) {
             if (char == ".") {
-              if (isAbbr(i) || isNumber(i) || isPotentialAbbr(i)) {
+              if (((isAbbr(i) || isPotentialAbbr(i)) && !/^\.\s[A-Z]/.test(text.slice(i))) || isNumber(i)) {
                 i += 1
                 continue
               }

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -82,7 +82,7 @@ export function registerPrompt() {
           i += 1
         }
         for (let i = 0; i < sentences.length; i++) {
-          ztoolkit.UI.appendElement(
+          const span = ztoolkit.UI.appendElement(
             {
               tag: "span",
               id: `sentence-${i}`,
@@ -95,21 +95,27 @@ export function registerPrompt() {
               listeners: [
                 {
                   type: "mousemove",
-                  listener: function () {
-                    const highlightColor = "#fee972"
-                    // @ts-ignore
-                    const span = this as HTMLSpanElement
-                    const parentNode = span.parentNode as HTMLDivElement
-                    parentNode?.querySelectorAll("span").forEach(e => e.style.backgroundColor = "")
+                  listener: () => {
+                    const highlightColor = "#fee972";
+
+                    let twinNode = [...container.querySelectorAll(".text-container")]
+                      .find(e => e != node) as HTMLDivElement;
+
+                    node.querySelectorAll("span").forEach(e => e.style.backgroundColor = "")
                     span.style.backgroundColor = highlightColor
-                    const siblingNode = (parentNode?.previousSibling?.previousSibling || parentNode?.nextSibling?.nextSibling) as HTMLDivElement
-                    siblingNode?.querySelectorAll("span").forEach(e => e.style.backgroundColor = "");
-                    const twinSpan = siblingNode.querySelector(`span[id=sentence-${i}]`) as HTMLSpanElement
+                    
+                    twinNode?.querySelectorAll("span").forEach(e => e.style.backgroundColor = "");
+
+                    const twinSpan = twinNode.querySelector(`span[id=sentence-${i}]`) as HTMLSpanElement
+
                     twinSpan.style.backgroundColor = highlightColor;
-                    if (direction == "column" && siblingNode.classList.contains("result")) {
-                      siblingNode.scrollTo(0, twinSpan.offsetTop - siblingNode.offsetHeight * .5 - parentNode.offsetHeight);
+
+                    const twinNodeContainer = twinNode.parentNode as HTMLDivElement;
+                    const nodeContainer = node.parentNode as HTMLDivElement;
+                    if (direction == "column" && twinNode.classList.contains("result")) {
+                      twinNodeContainer.scrollTo(0, twinSpan.offsetTop - twinNodeContainer.offsetHeight * .5 - nodeContainer.offsetHeight);
                     } else {
-                      siblingNode.scrollTo(0, twinSpan.offsetTop - siblingNode.offsetHeight * .5);
+                      twinNodeContainer.scrollTo(0, twinSpan.offsetTop - twinNodeContainer.offsetHeight * .5);
                     }
                   }
                 }
@@ -151,7 +157,7 @@ export function registerPrompt() {
           children: [
             {
               tag: "div",
-              classList: [className],
+              classList: [className, "text-container"],
               styles: {
                 fontSize: "1em",
                 lineHeight: "1.5em",
@@ -160,7 +166,7 @@ export function registerPrompt() {
             }
           ]
         });
-        addSentences(subContainer.querySelector(`.${className}`)!, text, dividers);
+        addSentences(subContainer.querySelector(".text-container")!, text, dividers);
         subContainers.push(subContainer);
       })
 
@@ -180,12 +186,12 @@ export function registerPrompt() {
       const W = rect.width;
       const mouseDownHandler = function (e: MouseEvent) {
         // hide
-        [rawDiv, resultDiv].forEach(div => {
+        subContainers.forEach(div => {
           div.querySelectorAll("span").forEach((e: HTMLSpanElement) => e.style.display = "none")
         })
         y = e.clientY;
         x = e.clientX;
-        const rect = resultDiv.getBoundingClientRect()
+        const rect = subContainers[1].getBoundingClientRect()
         h = rect.height;
         w = rect.width;
         document.addEventListener('mousemove', mouseMoveHandler);
@@ -195,17 +201,17 @@ export function registerPrompt() {
         const dy = e.clientY - y;
         const dx = e.clientX - x;
         if (direction == "column") {
-          resultDiv.style.height = `${h - dy}px`;
-          rawDiv.style.height = `${H - (h - dy) - size}px`;
+          subContainers[1].style.height = `${h - dy}px`;
+          subContainers[0].style.height = `${H - (h - dy) - size}px`;
         }
         if (direction == "row") {
-          resultDiv.style.width = `${w - dx}px`;
-          rawDiv.style.width = `${W - (w - dx) - size}px`;
+          subContainers[1].style.width = `${w - dx}px`;
+          subContainers[0].style.width = `${W - (w - dx) - size}px`;
         }
       };
       const mouseUpHandler = function () {
         // show
-        [rawDiv, resultDiv].forEach(div => {
+        subContainers.forEach(div => {
           div.querySelectorAll("span").forEach((e: HTMLSpanElement) => e.style.display = "")
         })
         document.removeEventListener('mousemove', mouseMoveHandler);

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -1,0 +1,107 @@
+import { config } from "../../package.json";
+
+export function registerPrompt() {
+  ztoolkit.Prompt.register([{
+    name: "Translate Sentences",
+    label: "Translate",
+    when: () => {
+      const selection = ztoolkit.Reader.getSelectedText(
+        Zotero.Reader.getByTabID(Zotero_Tabs.selectedID)
+      );
+      ztoolkit.log(selection)
+      return selection.length > 0
+    },
+    callback: (prompt) => {
+      const selection = ztoolkit.Reader.getSelectedText(
+        Zotero.Reader.getByTabID(Zotero_Tabs.selectedID)
+      );
+      const container = prompt.createCommandsContainer() as HTMLDivElement
+      container.style = `
+          padding: .5em;
+          display: flex;
+          flex-direction: row;
+          justify-content: space-between;
+        `
+      const queue = Zotero.PDFTranslate.data.translate.queue
+      const task = queue.find((i: any) => i.raw == selection) || queue.slice(-1)[0]
+      if (!task) {
+        prompt.showTip("Task is Null.")
+      }
+      const rawText = task.raw, resultText = task.result;
+      const props = {
+        styles: {
+          width: "49%",
+          height: "20em",
+          border: "1px solid #eee",
+          textAlign: "justify",
+          padding: ".5em",
+          fontSize: "1em",
+          lineHeight: "1.5em",
+          overflowY: "auto",
+        },
+      }
+      // TODO: prefs
+      let addSentences = (node: HTMLElement, text: string, sep: string) => {
+        let sentences = text.match(new RegExp(`.+?${sep}\\s*`, "g"))! as string[]
+        let i = 0
+        while (i < sentences.length - 1) {
+          if (
+            // Fig. 5
+            /(table|fig|figure)\.\s*$/i.test(sentences[i]) ||
+            // et al.,
+            (/(et al)\.$/i.test(sentences[i]) && /^,/i.test(sentences[i + 1])) ||
+            // 2.33
+            (/\d\.$/i.test(sentences[i]) && /^\d/i.test(sentences[i + 1]))
+          ) {
+            console.log(sentences[i], "-", sentences[i + 1])
+            sentences[i] = sentences[i] + sentences[i + 1]
+            sentences.splice(i + 1, 1)
+          } else {
+            i += 1
+          }
+        }
+        sentences = sentences.filter(s => s.length > 0)
+        console.log(sentences)
+        for (let i = 0; i < sentences.length; i++) {
+          console.log(sentences[i])
+          node.appendChild(ztoolkit.UI.createElement(document, "span", {
+            id: `sentence-${i}`,
+            properties: {
+              innerText: sentences[i]
+            },
+            styles: {
+              borderRadius: "3px"
+            },
+            listeners: [
+              {
+                type: "mousemove",
+                listener: function () {
+                  const hightlightColor = "#fee972"
+                  // @ts-ignore
+                  const span = this as HTMLSpanElement
+                  const parentNode = span.parentNode as HTMLDivElement
+                  parentNode?.querySelectorAll("span").forEach(e => e.style.backgroundColor = "")
+                  span.style.backgroundColor = hightlightColor
+                  const siblingNode = (parentNode?.previousSibling || parentNode?.nextSibling) as HTMLDivElement
+                  siblingNode?.querySelectorAll("span").forEach(e => e.style.backgroundColor = "");
+                  const twinSpan = siblingNode.querySelector(`span[id=sentence-${i}]`) as HTMLSpanElement
+                  twinSpan.style.backgroundColor = hightlightColor;
+                  siblingNode.scrollTo(0, twinSpan.offsetTop - siblingNode.offsetHeight * .5);
+                }
+              }
+            ]
+          }))
+        }
+      }
+      const rawDiv = ztoolkit.UI.createElement(document, "div", {
+        ...props
+      })
+      addSentences(rawDiv, rawText, "[\\.;]")
+      const resultDiv = ztoolkit.UI.createElement(document, "div", {
+        ...props,
+      })
+      addSentences(resultDiv, resultText, "[。;；]")
+      container.append(rawDiv, resultDiv)
+    }
+  }])
+}

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -37,7 +37,6 @@ export function registerPrompt() {
         // https://www.npmjs.com/package/sentence-extractor?activeTab=explore
         const abbrs = ["a.m.", "p.m.", "etc.", "vol.", "inc.", "jr.", "dr.", "tex.", "co.", "prof.", "rev.", "revd.", "hon.", "v.s.", "ie.",
           "eg.", "e.g.", "et al.", "st.", "ph.d.", "capt.", "mr.", "mrs.", "ms."]
-        const abbrLength = 2
         let isAbbr = (i: number) => {
           return abbrs.find((abbr: string) => {
             return (


### PR DESCRIPTION
```display mode: column```
![image](https://user-images.githubusercontent.com/51939531/220071405-49c12867-e9c4-40b0-a367-eaa5faccbda8.png)

```display mode: row```
![image](https://user-images.githubusercontent.com/51939531/220079027-d1e0ad14-9eda-4152-aa93-aa8ab049df76.png)

#300 

This feature is very convenient for viewing large passages of text in their original translations.

There is a basic assumption: the translation engine does not split a sentence into multiple translations. The number of sentences in the original translation is the same.

This function is based on **manual sentence segmentation**, so it works with **all translation engines**. 

Currently, **only** English to Chinese translation is supported. 
So I have added the following restrictions so that mismatched translation configurations will not display this command.

```ts
when: () => {
  const selection = ztoolkit.Reader.getSelectedText(
    Zotero.Reader.getByTabID(Zotero_Tabs.selectedID)
  );
  const sl = Zotero.Prefs.get("ZoteroPDFTranslate.sourceLanguage") as string
  const tl = Zotero.Prefs.get("ZoteroPDFTranslate.targetLanguage") as string
  return selection.length > 0 && Zotero?.PDFTranslate && sl.startsWith("en") && tl.startsWith("zh")
}
```

Two display modes are supported and the display mode setting can be written into the preferences (TODO).

**Can merge.**