### PR TITLE
feat: support custom gpt api url and custom special matching char

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -139,16 +139,6 @@
       preference="__prefsPrefix__.lineHeight"
     ></html:input>
   </hbox>
-  <hbox>
-    <label
-      value="&zotero.__addonRef__.pref.interface.splitChar.label;"
-    ></label>
-    <html:input
-      id="__addonRef__-splitChar"
-      type="text"
-      preference="__prefsPrefix__.splitChar"
-    ></html:input>
-  </hbox>
   <checkbox
     label="&zotero.__addonRef__.pref.interface.autoFocus.label;"
     native="true"
@@ -228,6 +218,15 @@
     <html:input
       type="text"
       preference="__prefsPrefix__.extraEngines"
+    ></html:input>
+  </hbox>
+  <hbox>
+    <label
+      value="&zotero.__addonRef__.pref.advanced.splitChar.label;"
+    ></label>
+    <html:input
+      type="text"
+      preference="__prefsPrefix__.splitChar"
     ></html:input>
   </hbox>
 </groupbox>

--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -139,6 +139,16 @@
       preference="__prefsPrefix__.lineHeight"
     ></html:input>
   </hbox>
+  <hbox>
+    <label
+      value="&zotero.__addonRef__.pref.interface.splitChar.label;"
+    ></label>
+    <html:input
+      id="__addonRef__-splitChar"
+      type="text"
+      preference="__prefsPrefix__.splitChar"
+    ></html:input>
+  </hbox>
   <checkbox
     label="&zotero.__addonRef__.pref.interface.autoFocus.label;"
     native="true"

--- a/addon/chrome/locale/en-US/addon.properties
+++ b/addon/chrome/locale/en-US/addon.properties
@@ -67,6 +67,7 @@ service.deeplcustom.secret.fail=Docs
 service.gpt.secret.pass=Config
 service.gpt.secret.fail=Config
 service.gpt.dialog.title=GPT Config
+service.gpt.dialog.url=API
 service.gpt.dialog.models=Model
 service.gpt.dialog.temperature=Temp
 service.gpt.dialog.status=Status

--- a/addon/chrome/locale/en-US/overlay.dtd
+++ b/addon/chrome/locale/en-US/overlay.dtd
@@ -28,6 +28,7 @@
 <!ENTITY zotero.__addonRef__.pref.interface.label "User Interface">
 <!ENTITY zotero.__addonRef__.pref.interface.fontSize.label "Font Size">
 <!ENTITY zotero.__addonRef__.pref.interface.lineHeight.label "Line Height">
+<!ENTITY zotero.__addonRef__.pref.interface.splitChar.label "Split Char">
 <!ENTITY zotero.__addonRef__.pref.interface.autoFocus.label "SideBar: Auto Focus">
 <!ENTITY zotero.__addonRef__.pref.interface.showSidebarEngine.label "SideBar: Show Engine Selection Menu">
 <!ENTITY zotero.__addonRef__.pref.interface.showSidebarSettings.label "SideBar: Show Settings">

--- a/addon/chrome/locale/en-US/overlay.dtd
+++ b/addon/chrome/locale/en-US/overlay.dtd
@@ -28,7 +28,6 @@
 <!ENTITY zotero.__addonRef__.pref.interface.label "User Interface">
 <!ENTITY zotero.__addonRef__.pref.interface.fontSize.label "Font Size">
 <!ENTITY zotero.__addonRef__.pref.interface.lineHeight.label "Line Height">
-<!ENTITY zotero.__addonRef__.pref.interface.splitChar.label "Split Char">
 <!ENTITY zotero.__addonRef__.pref.interface.autoFocus.label "SideBar: Auto Focus">
 <!ENTITY zotero.__addonRef__.pref.interface.showSidebarEngine.label "SideBar: Show Engine Selection Menu">
 <!ENTITY zotero.__addonRef__.pref.interface.showSidebarSettings.label "SideBar: Show Settings">
@@ -46,5 +45,6 @@
 <!ENTITY zotero.__addonRef__.pref.advanced.disabledLanguages.label "Disable Automatic Translation when File Language is(split with ',')">
 <!ENTITY zotero.__addonRef__.pref.advanced.disabledLanguages.alert "Reopen files/restart Zotero to apply.">
 <!ENTITY zotero.__addonRef__.pref.advanced.extraEngines.label "Extra engines in standalone window(split with ',')">
+<!ENTITY zotero.__addonRef__.pref.advanced.splitChar.label "Split Character(between text and translation)">
 
 <!ENTITY zotero.__addonRef__.pref.about.label "About">

--- a/addon/chrome/locale/zh-CN/addon.properties
+++ b/addon/chrome/locale/zh-CN/addon.properties
@@ -67,6 +67,7 @@ service.deeplcustom.secret.fail=文档
 service.gpt.secret.pass=配置
 service.gpt.secret.fail=配置
 service.gpt.dialog.title=GPT 配置项
+service.gpt.dialog.url=接口
 service.gpt.dialog.models=模型
 service.gpt.dialog.temperature=温度
 service.gpt.dialog.status=状态

--- a/addon/chrome/locale/zh-CN/overlay.dtd
+++ b/addon/chrome/locale/zh-CN/overlay.dtd
@@ -28,6 +28,7 @@
 <!ENTITY zotero.__addonRef__.pref.interface.label "用户界面">
 <!ENTITY zotero.__addonRef__.pref.interface.fontSize.label "字体大小">
 <!ENTITY zotero.__addonRef__.pref.interface.lineHeight.label "行高">
+<!ENTITY zotero.__addonRef__.pref.interface.splitChar.label "分隔符">
 <!ENTITY zotero.__addonRef__.pref.interface.autoFocus.label "侧边栏: 自动聚焦">
 <!ENTITY zotero.__addonRef__.pref.interface.showSidebarEngine.label "侧边栏: 显示翻译引擎选择菜单">
 <!ENTITY zotero.__addonRef__.pref.interface.showSidebarLanguage.label "侧边栏: 显示语言选择菜单">

--- a/addon/chrome/locale/zh-CN/overlay.dtd
+++ b/addon/chrome/locale/zh-CN/overlay.dtd
@@ -28,7 +28,6 @@
 <!ENTITY zotero.__addonRef__.pref.interface.label "用户界面">
 <!ENTITY zotero.__addonRef__.pref.interface.fontSize.label "字体大小">
 <!ENTITY zotero.__addonRef__.pref.interface.lineHeight.label "行高">
-<!ENTITY zotero.__addonRef__.pref.interface.splitChar.label "分隔符">
 <!ENTITY zotero.__addonRef__.pref.interface.autoFocus.label "侧边栏: 自动聚焦">
 <!ENTITY zotero.__addonRef__.pref.interface.showSidebarEngine.label "侧边栏: 显示翻译引擎选择菜单">
 <!ENTITY zotero.__addonRef__.pref.interface.showSidebarLanguage.label "侧边栏: 显示语言选择菜单">
@@ -46,5 +45,6 @@
 <!ENTITY zotero.__addonRef__.pref.advanced.disabledLanguages.label "对特定语言文件关闭自动翻译(用','分隔)">
 <!ENTITY zotero.__addonRef__.pref.advanced.disabledLanguages.alert "重新打开文件/重启Zotero以应用更改。">
 <!ENTITY zotero.__addonRef__.pref.advanced.extraEngines.label "独立窗口额外翻译引擎(用','分隔)">
+<!ENTITY zotero.__addonRef__.pref.advanced.splitChar.label "分隔符(原文与翻译之间)">
 
 <!ENTITY zotero.__addonRef__.pref.about.label "关于">

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -11,6 +11,7 @@ pref("__prefsPrefix__.sourceLanguage", "en-US");
 pref("__prefsPrefix__.targetLanguage", "");
 pref("__prefsPrefix__.fontSize", "12");
 pref("__prefsPrefix__.lineHeight", "1.5");
+pref("__prefsPrefix__.splitChar", "\ud83d\udd24");
 pref("__prefsPrefix__.autoFocus", true);
 pref("__prefsPrefix__.rawResultOrder", false);
 pref("__prefsPrefix__.showSidebarEngine", true);

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -36,5 +36,6 @@ pref("__prefsPrefix__.showPlayBtn", true);
 pref("__prefsPrefix__.disabledLanguages", "");
 pref("__prefsPrefix__.extraEngines", "");
 pref("__prefsPrefix__.titleColumnMode", "raw");
+pref("__prefsPrefix__.gptUrl", "https://api.openai.com/v1/chat/completions");
 pref("__prefsPrefix__.gptModel", "gpt-3.5-turbo");
 pref("__prefsPrefix__.gptTemperature", "1.0");

--- a/src/modules/services.ts
+++ b/src/modules/services.ts
@@ -114,7 +114,14 @@ export class TranslationServices {
       return false;
     }
     // Remove possible translation results (for annotations).
-    task.raw = task.raw.replace(/🔤[\s\S]*🔤/g, "");
+    const splitChar = task.raw.includes(getPref("splitChar") as string) 
+      ? ""
+      : getPref("splitChar");
+    // /🔤[^🔤]*🔤/g
+    const regex = splitChar === ""
+      ? ""
+      : new RegExp(`${splitChar}[^${splitChar}]*${splitChar}`, "g");
+    task.raw = task.raw.replace(regex, "");
     task.result = "";
     // Display raw
     if (!options.noDisplay) {
@@ -170,14 +177,16 @@ export class TranslationServices {
                 (savePosition === "comment"
                   ? item.annotationComment
                   : item.annotationText) || ""
-              ).replace(/🔤[\s\S]*🔤/g, "");
+              ).replace(regex, "");
+              let text = `${
+                currentText[currentText.length - 1] === "\n" ? "" : "\n"
+              }${splitChar}${task.result}${splitChar}\n`;
+              text = splitChar === "" ? text : `${currentText}${text}`;
               item[
                 savePosition === "comment"
                   ? "annotationComment"
                   : "annotationText"
-              ] = `${currentText}${
-                currentText[currentText.length - 1] === "\n" ? "" : "\n"
-              }🔤${task.result}🔤\n`;
+              ] = text;
               item.saveTx();
             }
           }

--- a/src/modules/services/gpt.ts
+++ b/src/modules/services/gpt.ts
@@ -5,9 +5,10 @@ import { getServiceSecret } from "../../utils/translate";
 export const gptTranslate = <TranslateTaskProcessor>async function (data) {
   const model = getPref("gptModel");
   const temperature = parseFloat(getPref("gptTemperature") as string);
+  const apiUrl = getPref("gptUrl");
   const xhr = await Zotero.HTTP.request(
     "POST",
-    "https://api.openai.com/v1/chat/completions",
+    apiUrl,
     {
       headers: {
         "Content-Type": "application/json",

--- a/src/utils/gptModels.ts
+++ b/src/utils/gptModels.ts
@@ -6,6 +6,7 @@ export async function gptStatusCallback(status: boolean) {
   const selectedModel = getPref("gptModel");
   const dialog = new ztoolkit.Dialog(2, 1);
   const dialogData: { [key: string | number]: any } = {
+    url: getPref("gptUrl"),
     models: getPref("gptModel"),
     temperature: parseFloat(getPref("gptTemperature") as string),
     loadCallback: async () => {
@@ -68,6 +69,25 @@ export async function gptStatusCallback(status: boolean) {
           columnGap: "5px",
         },
         children: [
+          {
+            tag: "label",
+            namespace: "html",
+            attributes: {
+              for: "url",
+            },
+            properties: {
+              innerHTML: getString("service.gpt.dialog.url"),
+            },
+          },
+          {
+            tag: "input",
+            id: "gptUrl",
+            attributes: {
+              "data-bind": "url",
+              "data-prop": "value",
+              type: "string",
+            },
+          },
           {
             tag: "label",
             namespace: "html",
@@ -183,6 +203,7 @@ export async function gptStatusCallback(status: boolean) {
           setPref("gptTemperature", dialogData.temperature.toString());
         }
 
+        setPref("gptUrl", dialogData.url)
         setPref("gptModel", dialogData.models);
       }
       break;


### PR DESCRIPTION
### 1. 自定义GPT的接口地址
涉及问题： #419 
### 2. 支持修改特殊字符（用于区分翻译文本和原文本）
涉及问题：  
* #405 
* #411  
* #415

**注意**：
* 尽量保证仅包含一个字符，且该字符在原文中不存在，推荐[各种各样的emoji](https://unicode.org/emoji/charts/full-emoji-list.html)
* 不要使用保留字符，例如`$`、`/`、`\`、`?`等
* 支持留空，表示不添加任何字符
* **测试文件**下载：[zotero-pdf-translate.zip](https://github.com/windingwind/zotero-pdf-translate/files/11124817/zotero-pdf-translate.zip)


![1](https://user-images.githubusercontent.com/18099238/229198218-5920c536-954e-478c-9e26-c67d4be4dbfd.png)