### PR TITLE
feat: add button to hide popup textarea and fix #422

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -34,12 +34,21 @@
         />
       </radiogroup>
     </hbox>
-    <checkbox
-      id="__addonRef__-enablePopup"
-      label="&zotero.__addonRef__.pref.basic.enablePopup.label;"
-      native="true"
-      preference="__prefsPrefix__.enablePopup"
-    />
+    <hbox>
+      <checkbox
+        id="__addonRef__-enablePopup"
+        label="&zotero.__addonRef__.pref.basic.enablePopup.label;"
+        native="true"
+        preference="__prefsPrefix__.enablePopup"
+      />
+      <checkbox
+        id="__addonRef__-enableHidePopupTextarea"
+        class="enable-popup"
+        label="&zotero.__addonRef__.pref.basic.enableHidePopupTextarea.label;"
+        native="true"
+        preference="__prefsPrefix__.enableHidePopupTextarea"
+      />
+    </hbox>
     <hbox>
       <checkbox
         id="__addonRef__-enableAddToNote"

--- a/addon/chrome/locale/en-US/overlay.dtd
+++ b/addon/chrome/locale/en-US/overlay.dtd
@@ -1,6 +1,7 @@
 <!ENTITY zotero.__addonRef__.pref.general.label "General">
 <!ENTITY zotero.__addonRef__.pref.basic.enableAuto.label "Auto-Trans Selection">
 <!ENTITY zotero.__addonRef__.pref.basic.enablePopup.label "Enable Popup">
+<!ENTITY zotero.__addonRef__.pref.basic.enableHidePopupTextarea.label "Hide Popup Textarea">
 <!ENTITY zotero.__addonRef__.pref.basic.enableComment.label "Auto-Trans Annotation">
 <!ENTITY zotero.__addonRef__.pref.basic.annotationTranslationInComment.label "Save to Annotation Comment">
 <!ENTITY zotero.__addonRef__.pref.basic.annotationTranslationInBody.label "Save to Annotation Body">

--- a/addon/chrome/locale/zh-CN/overlay.dtd
+++ b/addon/chrome/locale/zh-CN/overlay.dtd
@@ -1,6 +1,7 @@
 <!ENTITY zotero.__addonRef__.pref.general.label "通用">
 <!ENTITY zotero.__addonRef__.pref.basic.enableAuto.label "自动翻译选择内容">
 <!ENTITY zotero.__addonRef__.pref.basic.enablePopup.label "启用弹窗">
+<!ENTITY zotero.__addonRef__.pref.basic.enableHidePopupTextarea.label "隐藏翻译弹窗">
 <!ENTITY zotero.__addonRef__.pref.basic.enableComment.label "自动翻译批注">
 <!ENTITY zotero.__addonRef__.pref.basic.annotationTranslationInComment.label "存在笔记评论">
 <!ENTITY zotero.__addonRef__.pref.basic.annotationTranslationInBody.label "存在笔记本身">

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -10,6 +10,7 @@ export function updateReaderPopup() {
     return;
   }
   const enablePopup = getPref("enablePopup");
+  const hidePopupTextarea = getPref("enableHidePopupTextarea") as boolean;
   Array.from(popup.querySelectorAll(`.${config.addonRef}-readerpopup`)).forEach(
     (elem) => ((elem as HTMLElement).hidden = !enablePopup)
   );
@@ -62,7 +63,7 @@ export function updateReaderPopup() {
     );
   }
   translateButton.hidden = task.status !== "waiting";
-  textarea.hidden = task.status === "waiting";
+  textarea.hidden = hidePopupTextarea || task.status === "waiting";
   textarea.value = task.result || task.raw;
   textarea.style.fontSize = `${getPref("fontSize")}px`;
   textarea.style.lineHeight = `${
@@ -96,6 +97,7 @@ export function buildReaderPopup(readerInstance: _ZoteroTypes.ReaderInstance) {
     `${config.addonRef}-${readerInstance._instanceID}-${type}`;
 
   const onTextAreaCopy = getOnTextAreaCopy(popup, makeId("text"));
+  const hidePopupTextarea = getPref("enableHidePopupTextarea") as boolean;
 
   ztoolkit.UI.appendElement(
     {
@@ -132,7 +134,7 @@ export function buildReaderPopup(readerInstance: _ZoteroTypes.ReaderInstance) {
                   button.ownerDocument.querySelector(
                     `#${makeId("text")}`
                   ) as HTMLTextAreaElement
-                ).hidden = false;
+                ).hidden = hidePopupTextarea;
               },
             },
           ],

--- a/src/modules/reader.ts
+++ b/src/modules/reader.ts
@@ -57,6 +57,10 @@ async function initializeReaderSelectionEvent(
     if (!target?.ownerDocument?.querySelector("#viewer")?.contains(target)) {
       return false;
     }
+    // Callback when the selected content is not null
+    if (!ztoolkit.Reader.getSelectedText(instance)) {
+      return false;
+    }
     addon.data.translate.concatKey = ev.altKey;
     addon.hooks.onReaderTextSelection(instance);
   }


### PR DESCRIPTION
1. Now, users can use button and panel to use translation, and the pop-up textarea becomes an option.

![image](https://user-images.githubusercontent.com/41108003/229824043-6d43fd16-20af-4ba7-8442-e5457810fa09.png)
![sreanshot](https://user-images.githubusercontent.com/41108003/229826885-b4d9adb1-7942-4831-9be8-be50be138ff0.gif)

2. Fixing the issue of triggering translation when no text is selected. 
#422
#390 (Maybe)
 