### PR TITLE
Add waiting time for batch translation using GPT

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -97,6 +97,12 @@
       <button id="__addonRef__-sentenceServicesStatus"></button>
     </hbox>
     <checkbox
+      id="__addonRef__-gptNoCreditCardDelay"
+      label="&zotero.__addonRef__.pref.service.gptNoCreditCardDelay.label;"
+      native="true"
+      preference="__prefsPrefix__.enableGptNoCreditCardDelay"
+    />
+    <checkbox
       id="__addonRef__-useWordService"
       label="&zotero.__addonRef__.pref.service.useWordService.label;"
       native="true"

--- a/addon/chrome/locale/en-US/overlay.dtd
+++ b/addon/chrome/locale/en-US/overlay.dtd
@@ -13,6 +13,7 @@
 <!ENTITY zotero.__addonRef__.pref.service.label "Service">
 <!ENTITY zotero.__addonRef__.pref.service.sentenceServices.label "Translation Services">
 <!ENTITY zotero.__addonRef__.pref.service.sentenceServicesSecret.label "Secret">
+<!ENTITY zotero.__addonRef__.pref.service.gptNoCreditCardDelay.label "Use 21s Delay Time for an OpenAI User Who are NOT Tied to a Credit Card in Batch Translate Task">
 <!ENTITY zotero.__addonRef__.pref.service.useWordService.label "Use Dictionary Service for Word Translation">
 <!ENTITY zotero.__addonRef__.pref.service.wordServices.label "Dictionary Services">
 <!ENTITY zotero.__addonRef__.pref.service.wordServicesSecret.label "Secret">

--- a/addon/chrome/locale/zh-CN/overlay.dtd
+++ b/addon/chrome/locale/zh-CN/overlay.dtd
@@ -13,6 +13,7 @@
 <!ENTITY zotero.__addonRef__.pref.service.label "服务">
 <!ENTITY zotero.__addonRef__.pref.service.sentenceServices.label "翻译服务">
 <!ENTITY zotero.__addonRef__.pref.service.sentenceServicesSecret.label "密钥">
+<!ENTITY zotero.__addonRef__.pref.service.gptNoCreditCardDelay.label "对于没有添加信用卡的OpenAI用户, 如果要批量翻译, 请务必勾选此选项增加21秒等待时间">
 <!ENTITY zotero.__addonRef__.pref.service.useWordService.label "使用字典服务翻译词语">
 <!ENTITY zotero.__addonRef__.pref.service.wordServices.label "字典服务">
 <!ENTITY zotero.__addonRef__.pref.service.wordServicesSecret.label "密钥">

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -1,4 +1,5 @@
 pref("__prefsPrefix__.enableAuto", true);
+pref("__prefsPrefix__.enableGptNoCreditCardDelay", false);
 pref("__prefsPrefix__.enableDict", true);
 pref("__prefsPrefix__.enablePopup", true);
 pref("__prefsPrefix__.enableComment", true);

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -30,6 +30,7 @@ class Addon {
       queue: TranslateTask[];
       maximumQueueLength: number;
       batchTaskDelay: number;
+      batchTaskDelayGPT: number,
       services: TranslationServices;
     };
   };
@@ -53,6 +54,7 @@ class Addon {
         queue: [],
         maximumQueueLength: 100,
         batchTaskDelay: 1000,
+        batchTaskDelayGPT: 21000,
         services: new TranslationServices(),
       },
     };

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -30,7 +30,7 @@ class Addon {
       queue: TranslateTask[];
       maximumQueueLength: number;
       batchTaskDelay: number;
-      batchTaskDelayGPT: number,
+      batchTaskDelayGPT: number;
       services: TranslationServices;
     };
   };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -158,23 +158,25 @@ async function onTranslateInBatch(
     Addon["data"]["translate"]["services"]["runTranslationTask"]
   >["1"] = {}
 ) {
+  let current:number = 0;
   for (const task of tasks) {
-    await addon.hooks.onTranslate(task, options);
+
     /**
      * Yuankun Liu (https://github.com/lyk7539511)
      *  
-     * Here, the `if` statement determines whether to use GPT as the translation engine. 
-     * If so, the waiting time for batch translation is increased from the original 1000 
-     * to 21000 to avoid triggering OpenAI's API call limit of 3 calls per minute. 
-     * This prevents missing translations due to missed wait times.
+     * OpenAI has an API call limit of three times per minute for users who 
+     * have not added a credit card. Therefore, it is up to the user to decide 
+     * whether to add a delay time to avoid triggering the limit condition.
      */
-    if (getPref('translateSource') === 'gpt') {
+
+    current += 1; // The first three translation tasks will never be delayed.
+    if (!(current <= 3) && getPref('enableGptNoCreditCardDelay')) {
       await Zotero.Promise.delay(addon.data.translate.batchTaskDelayGPT);
     }
     else {
       await Zotero.Promise.delay(addon.data.translate.batchTaskDelay);
     }
-      
+    await addon.hooks.onTranslate(task, options);      
   }
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -170,7 +170,7 @@ async function onTranslateInBatch(
      */
 
     current += 1; // The first three translation tasks will never be delayed.
-    if (!(current <= 3) && getPref('enableGptNoCreditCardDelay')) {
+    if (!(current <= 3) && getPref('enableGptNoCreditCardDelay') && (getPref('translateSource') === 'gpt')) {
       await Zotero.Promise.delay(addon.data.translate.batchTaskDelayGPT);
     }
     else {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -160,7 +160,21 @@ async function onTranslateInBatch(
 ) {
   for (const task of tasks) {
     await addon.hooks.onTranslate(task, options);
-    await Zotero.Promise.delay(addon.data.translate.batchTaskDelay);
+    /**
+     * Yuankun Liu (https://github.com/lyk7539511)
+     *  
+     * Here, the `if` statement determines whether to use GPT as the translation engine. 
+     * If so, the waiting time for batch translation is increased from the original 1000 
+     * to 21000 to avoid triggering OpenAI's API call limit of 3 calls per minute. 
+     * This prevents missing translations due to missed wait times.
+     */
+    if (getPref('translateSource') === 'gpt') {
+      await Zotero.Promise.delay(addon.data.translate.batchTaskDelayGPT);
+    }
+    else {
+      await Zotero.Promise.delay(addon.data.translate.batchTaskDelay);
+    }
+      
   }
 }
 

--- a/src/modules/preferenceWindow.ts
+++ b/src/modules/preferenceWindow.ts
@@ -196,6 +196,12 @@ function buildPrefsPane() {
     });
 
   doc
+    .querySelector(`#${makeId("gptNoCreditCardDelay")}`)
+    ?.addEventListener("command", (e: Event) => {
+      onPrefsEvents("setGptNoCreditCardDelay");
+    });
+
+  doc
     .querySelector(`#${makeId("useWordService")}`)
     ?.addEventListener("command", (e: Event) => {
       onPrefsEvents("setUseWordService");
@@ -229,6 +235,7 @@ function buildPrefsPane() {
 function updatePrefsPaneDefault() {
   onPrefsEvents("setAutoTranslateAnnotation", false);
   onPrefsEvents("setEnablePopup", false);
+  onPrefsEvents("setGptNoCreditCardDelay", false)
   onPrefsEvents("setUseWordService", false);
   onPrefsEvents("setSentenceSecret", false);
   onPrefsEvents("setWordSecret", false);
@@ -283,6 +290,16 @@ function onPrefsEvents(type: string, fromElement: boolean = true) {
           : (getPref("enableNote") as boolean);
         const hidden = !elemValue;
         setDisabled("enable-popup-addtonote", hidden);
+      }
+      break;
+    case "setGptNoCreditCardDelay":
+      {
+        let elemValue = fromElement
+          ? (doc.querySelector(`#${makeId("gptNoCreditCardDelay")}`) as XUL.Checkbox)
+              .checked
+          : (getPref("enableGptNoCreditCardDelay") as boolean);
+        const hidden = !elemValue;
+        setDisabled("enable-gpt-no-credit-card-delay", hidden);
       }
       break;
     case "setUseWordService":


### PR DESCRIPTION
## Related issue
#460

## Feature
Added `batchTaskDelayGPT: number` to specifically control the batch translation waiting time when using the GPT engine.
OpenAI officially limits API calls to three times per minute. Here, the waiting time is set to 21 seconds to avoid triggering OpenAI's limit during batch translation.
Improved compatibility of the plugin.

## Implementation
When calling the `onTranslateInBatch()` function, it determines whether the current translation engine is GPT. If so, it uses the waiting time defined by `batchTaskDelayGPT`, otherwise it continues to use `batchTaskDelay`.

## Issues
Batch translation can directly cause a slow translation feeling, but it does not affect non-GPT engines.