### PR TITLE
refactor: use `replaceAll()` instead of `eval()`

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -43,7 +43,7 @@ pref("__prefsPrefix__.gptModel", "gpt-3.5-turbo");
 pref("__prefsPrefix__.gptTemperature", "1.0");
 pref(
   "__prefsPrefix__.gptPrompt",
-  "As an academic expert with specialized knowledge in various fields, please provide a proficient and precise translation translation from ${data.langfrom} to ${data.langto} of the academic text enclosed in 🔤. It is crucial to maintaining the original phrase or sentence and ensure accuracy while utilizing the appropriate language. The text is as follows:  🔤 ${data.raw} 🔤  Please provide the translated result without any additional explanation and remove 🔤.",
+  "As an academic expert with specialized knowledge in various fields, please provide a proficient and precise translation translation from ${langFrom} to ${langTo} of the academic text enclosed in 🔤. It is crucial to maintaining the original phrase or sentence and ensure accuracy while utilizing the appropriate language. The text is as follows:  🔤 ${sourceText} 🔤  Please provide the translated result without any additional explanation and remove 🔤.",
 );
 pref(
   "__prefsPrefix__.cnkiRegex",

--- a/src/modules/services/gpt.ts
+++ b/src/modules/services/gpt.ts
@@ -6,6 +6,14 @@ export const gptTranslate = <TranslateTaskProcessor>async function (data) {
   const model = getPref("gptModel");
   const temperature = parseFloat(getPref("gptTemperature") as string);
   const apiUrl = getPref("gptUrl");
+
+  function transformContent(langFrom: string, langTo: string, sourceText: string) {
+    return (getPref("gptPrompt") as string)
+      .replaceAll("${langFrom}", langFrom)
+      .replaceAll("${langTo}", langTo)
+      .replaceAll("${sourceText}", sourceText);
+  }
+
   const xhr = await Zotero.HTTP.request("POST", apiUrl, {
     headers: {
       "Content-Type": "application/json",
@@ -16,7 +24,7 @@ export const gptTranslate = <TranslateTaskProcessor>async function (data) {
       messages: [
         {
           role: "user",
-          content: eval((("`" + getPref("gptPrompt")) as string) + "`"),
+          content: transformContent(data.langfrom, data.langto, data.raw),
         },
       ],
       temperature: temperature,


### PR DESCRIPTION
`eval()` is slower than the alternatives, and it is also unsafe. Using template string instead to avoid `eval()` calls.

reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!
