### PR TITLE
chore: add pre-commit hook to format files before commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,3 @@
+{
+  "*.{mjs,js,ts,json}": ["prettier --write"]
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "release": "npm run lint && release-it",
     "lint": "prettier --write . && eslint . --ext .ts --fix",
     "update-deps": "npm update --save",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -55,6 +56,8 @@
     "esbuild": "^0.17.19",
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^8.9.0",
+    "husky": "^8.0.3",
+    "lint-staged": "^14.0.1",
     "prettier": "^3.0.0",
     "release-it": "^15.11.0",
     "replace-in-file": "^7.0.1",


### PR DESCRIPTION
We have [setup pre-commit hook to format documents before commit for mdn/translated-content](https://github.com/mdn/translated-content/pull/8181). It might be a good idea to do the same thing in this project.
