### PR TITLE
fix(service/microsoft): remove the explicitly specified content-length

### DIFF
--- a/src/modules/services/microsoft.ts
+++ b/src/modules/services/microsoft.ts
@@ -1,24 +1,18 @@
 import { TranslateTaskProcessor } from "../../utils/task";
 
 export default <TranslateTaskProcessor>async function (data) {
-  const req_body = JSON.stringify([
-    {
-      text: data.raw,
-    },
-  ]);
+  const reqBody = JSON.stringify([{ Text: data.raw }]);
 
   const xhr = await Zotero.HTTP.request(
     "POST",
     `https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&to=${data.langto}`,
     {
       headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        Host: "api.cognitive.microsofttranslator.com",
-        "Content-Length": req_body.length,
+        "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": data.secret,
       },
       responseType: "json",
-      body: req_body,
+      body: reqBody,
     },
   );
   if (xhr?.status !== 200) {


### PR DESCRIPTION
Fixes: #510

I believe that the http client of Zotero would set the correct content-length header. And this is [a forbidden header](https://developer.mozilla.org/docs/Glossary/Forbidden_header_name), which means that the programmer should not explicitly set this (the user agent would set this correctly).

For the issue mentioned in #510, it could not translate from Chinere to English. And the status code returned is 400. So this might be due to setting of wrong Content-Length and zotero does not implicitly reject the setting. For unicode other than ascii, the string length is not equal to the content-length. Which has made this error.

Resolving this by removing `Content-Length` header.

Documentation: https://learn.microsoft.com/en-us/azure/ai-services/translator/reference/v3-0-reference

Tested this locally:

![image](https://github.com/windingwind/zotero-pdf-translate/assets/15844309/45a0c849-e192-43f8-8464-3b91525ed349)
