### PR TITLE
fix: use RFC3986 URL component format to encode body

### DIFF
--- a/src/modules/services/aliyun.ts
+++ b/src/modules/services/aliyun.ts
@@ -14,9 +14,16 @@ export default <TranslateTaskProcessor>async function (data) {
     return str.split("-")[0];
   }
 
+  function encodeRFC3986URIComponent(str: string) {
+    return encodeURIComponent(str).replace(
+      /[!'()*]/g,
+      (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+    );
+  }
+
   const encodedBody = `AccessKeyId=${accessKeyId}&Action=TranslateGeneral&Format=JSON&FormatType=text&SignatureMethod=HMAC-SHA1&SignatureNonce=${encodeURIComponent(
     randomString(12),
-  )}&SignatureVersion=1.0&SourceLanguage=auto&SourceText=${encodeURIComponent(
+  )}&SignatureVersion=1.0&SourceLanguage=auto&SourceText=${encodeRFC3986URIComponent(
     data.raw,
   )}&TargetLanguage=${languageCode(data.langto)}&Timestamp=${encodeURIComponent(
     new Date().toISOString(),

--- a/src/modules/services/tencent.ts
+++ b/src/modules/services/tencent.ts
@@ -17,10 +17,9 @@ export default <TranslateTaskProcessor>async function (data) {
   function encodeRFC5987ValueChars(str: string) {
     return encodeURIComponent(str)
       .replace(
-        /['()]/g,
+        /['()*]/g,
         (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
-      ) // i.e., %27 %28 %29
-      .replace(/\*/g, "%2A")
+      ) // i.e., %27 %28 %29 %2A
       .replace(/%20/g, "+");
   }
 


### PR DESCRIPTION
Fixes: #566

Reference:

- https://help.aliyun.com/zh/sdk/product-overview/rpc-mechanism#sectiondiv-6jf-89b-wfa
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_rfc3986

![image](https://github.com/windingwind/zotero-pdf-translate/assets/15844309/ca3638dd-7f1a-47f2-adb8-23c303520041)

