### PR TITLE
为DeepL服务添加了用户自定义词典Glossaries

### DIFF
--- a/src/modules/services/deepl.ts
+++ b/src/modules/services/deepl.ts
@@ -15,11 +15,16 @@ export const deeplpro = <TranslateTaskProcessor>async function (data) {
 };
 
 async function deepl(url: string, data: Required<TranslateTask>) {
-  const reqBody = `auth_key=${data.secret}&text=${encodeURIComponent(
+  const secret: string = data.secret;
+  const [key, glossary_id]: string[] = secret.split("#");
+  let reqBody = `auth_key=${data.secret}&text=${encodeURIComponent(
     data.raw,
   )}&source_lang=${data.langfrom
     .split("-")[0]
     .toUpperCase()}&target_lang=${data.langto.split("-")[0].toUpperCase()}`;
+  if (glossary_id) {
+    reqBody += `&glossary_id=${glossary_id}`;
+  }
   const xhr = await Zotero.HTTP.request("POST", url, {
     responseType: "json",
     body: reqBody,


### PR DESCRIPTION
DeepL为用户提供了(Glossaries词汇表)[https://www.deepl.com/docs-api/glossaries]功能, 在翻译学术论文时, 有些词汇往往具有特殊的含义, 添加词汇表能够帮助DeepL更好的翻译这些内容.  我参考了您在【有道智能云】接口中的定义, 在输入DeepL接口的Token时, 可以使用井号"#", 后接Glossaries-ID, 这样在请求时即可带上词汇表.  即使用户不使用词汇表, 原有的功能也不会改变
----
我无法使用`npm run build` 构建正确的xpi插件, 即使不修改源码我构建时也会出现tsc的编译错误, 由于我并不精通typescript, 因此我无法验证此commit是否正确. 但是相关代码已经在typescript playground中检查过可以运行.