### PR TITLE
Add DeepL glossary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The secret format is `MY_SECRET`.
 
 **DeepL Translate**  
 Apply [here](https://www.deepl.com/pro?cta=header-prices/#developer).
+The secret format is `secretToken` or `secretToken#glossaryId` (if you want to specify some translate glossary).
 
 **Youdao Zhiyun Translate 有道智云**  
 Apply [here](https://ai.youdao.com/login.s).  

--- a/src/modules/services/deepl.ts
+++ b/src/modules/services/deepl.ts
@@ -15,11 +15,15 @@ export const deeplpro = <TranslateTaskProcessor>async function (data) {
 };
 
 async function deepl(url: string, data: Required<TranslateTask>) {
-  const reqBody = `auth_key=${data.secret}&text=${encodeURIComponent(
+  const [key, glossary_id]: string[] = data.secret.split("#");
+  let reqBody = `auth_key=${key}&text=${encodeURIComponent(
     data.raw,
   )}&source_lang=${data.langfrom
     .split("-")[0]
     .toUpperCase()}&target_lang=${data.langto.split("-")[0].toUpperCase()}`;
+  if (glossary_id) {
+    reqBody += `&glossary_id=${glossary_id}`;
+  }
   const xhr = await Zotero.HTTP.request("POST", url, {
     responseType: "json",
     body: reqBody,


### PR DESCRIPTION
[DeepL Glossaries](https://www.deepl.com/docs-api/glossaries) is useful for me. While translating academic papers, some words' meaning are not common, which makes translator performance not well. Glossaries allow user add some translate pairs, like "instrumentation\t插桩\n". I have test this modify following [this](https://github.com/windingwind/zotero-pdf-translate/issues/597)

Before:
![image](https://github.com/windingwind/zotero-pdf-translate/assets/24435007/7b8db320-9bd7-4096-bb2e-d2e235768e98)

After:
![image](https://github.com/windingwind/zotero-pdf-translate/assets/24435007/cee01c20-c3d0-450f-b88d-7d73971234fc)


