### PR TITLE
fix: deeplx ICounts calculation mistake

### DIFF
--- a/src/modules/services/deeplx.ts
+++ b/src/modules/services/deeplx.ts
@@ -3,19 +3,9 @@ export default <TranslateTaskProcessor>async function (data) {
   const id = 1000 * (Math.floor(Math.random() * 99999) + 8300000) + 1;
   const url = "https://www2.deepl.com/jsonrpc";
   const t = data.raw;
-  let ICounts = 0;
-  let ts = Date.now();
-  for (let i = 0; i < t.length; i++) {
-    if (t[i] == "i") {
-      ICounts++;
-    }
-  }
-  if (ICounts != 0) {
-    ICounts++;
-    ts = ts - (ts % ICounts) + ICounts;
-  } else {
-    return;
-  }
+  const ICounts = (t.match(/i/g) || []).length + 1;
+  const ts = Date.now();
+
   let reqBody = JSON.stringify({
     jsonrpc: "2.0",
     method: "LMT_handle_texts",
@@ -32,7 +22,7 @@ export default <TranslateTaskProcessor>async function (data) {
         source_lang_user_selected: data.langfrom.split("-")[0].toUpperCase(),
         target_lang: data.langto.split("-")[0].toUpperCase(),
       },
-      timestamp: ts,
+      timestamp: ts - (ts % ICounts) + ICounts,
       commonJobParams: {
         wasSpoken: false,
         transcribe_as: "",


### PR DESCRIPTION
在 Deepl 的编码过程中通过计算翻译内容中的 i 的数量来防止被简单的重放攻击。

然而之前提交的计算方式直接将翻译内容中的 i 为 0 的情况 return 了，这导致如果请求翻译的内容不包含 i 字母，则翻译过程被终止无法请求。

