### PR TITLE
change model selection to input for custom model supports

### DIFF
--- a/addon/chrome/locale/en-US/addon.properties
+++ b/addon/chrome/locale/en-US/addon.properties
@@ -77,7 +77,7 @@ service.gpt.dialog.close=close
 service.gpt.dialog.status.load=loading
 service.gpt.dialog.status.available=available
 service.gpt.dialog.status.timeout=timeout
-service.gpt.dialog.status.invalid=secret invalid
+service.gpt.dialog.status.invalid=invalid OpenAI secret
 service.gpt.dialog.status.unexpect=fail
 
 readerpopup.translate.label=Translate

--- a/addon/chrome/locale/zh-CN/addon.properties
+++ b/addon/chrome/locale/zh-CN/addon.properties
@@ -77,7 +77,7 @@ service.gpt.dialog.close=关闭
 service.gpt.dialog.status.load=加载中
 service.gpt.dialog.status.available=可用
 service.gpt.dialog.status.timeout=请求超时
-service.gpt.dialog.status.invalid=密钥不可用
+service.gpt.dialog.status.invalid=无效的OpenAI密钥
 service.gpt.dialog.status.unexpect=服务不可用
 
 readerpopup.translate.label=翻译

--- a/src/utils/gptModels.ts
+++ b/src/utils/gptModels.ts
@@ -51,6 +51,7 @@ export async function gptStatusCallback(status: boolean) {
           `service.gpt.dialog.status.${gptStatus}`
         );
       }
+
     },
   };
 
@@ -99,21 +100,13 @@ export async function gptStatusCallback(status: boolean) {
             },
           },
           {
-            tag: "select",
+            tag: "input",
             id: "gptModels",
             attributes: {
               "data-bind": "models",
               "data-prop": "value",
+              type: "string",
             },
-            children: [
-              {
-                tag: "option",
-                properties: {
-                  value: selectedModel,
-                  innerHTML: selectedModel,
-                },
-              },
-            ],
           },
           {
             tag: "label",


### PR DESCRIPTION
类似issue #585，插件的zotero 6版本无法支持输入模型名来支持不同提供商的模型。
感觉与其手动添加不同模型支持，不如像手动填写url一样，手动填写模型名了。毕竟除了很多模型本身支持openai style api，也有各种api转发的开源工具。