### PR TITLE
支持Gemini流式回复

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -61,7 +61,7 @@ pref(
 );
 pref(
   "__prefsPrefix__.gemini.endPoint",
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest",
 );
 pref(
   "__prefsPrefix__.gemini.prompt",

--- a/src/modules/services/gemini.ts
+++ b/src/modules/services/gemini.ts
@@ -41,7 +41,7 @@ const geminiTranslate = async function (
         let result = "";
         xmlhttp.onprogress = (e: any) => {
           // Only concatenate the new strings
-          const newResponse = JSON.parse(e.target.response.slice(preLength));
+          const newResponse = e.target.response.slice(preLength);
           const dataArray = newResponse.split("data: ");
 
           for (const data of dataArray) {
@@ -55,6 +55,7 @@ const geminiTranslate = async function (
             e.target.timeout = 0;
           }
 
+          data.result = result;
           preLength = e.target.response.length;
 
           if (data.type === "text") {

--- a/src/modules/services/gemini.ts
+++ b/src/modules/services/gemini.ts
@@ -19,7 +19,7 @@ const geminiTranslate = async function (
 
   const xhr = await Zotero.HTTP.request(
     "POST",
-    apiURL + `?key=${data.secret}`,
+    apiURL + `:streamGenerateContent?alt=sse&key=${data.secret}`,
     {
       headers: {
         "Content-Type": "application/json",
@@ -42,14 +42,19 @@ const geminiTranslate = async function (
         xmlhttp.onprogress = (e: any) => {
           // Only concatenate the new strings
           const newResponse = JSON.parse(e.target.response.slice(preLength));
-          result = newResponse.candidates[0].content.parts[0].text;
+          const dataArray = newResponse.split("data: ");
+
+          for (const data of dataArray) {
+            if (data) {
+              result += JSON.parse(data).candidates[0].content.parts[0].text || "";
+            }
+          }
+
           // Clear timeouts caused by stream transfers
           if (e.target.timeout) {
             e.target.timeout = 0;
           }
 
-          // Remove \n\n from the beginning of the data
-          data.result = result.replace(/^\n\n/, "");
           preLength = e.target.response.length;
 
           if (data.type === "text") {


### PR DESCRIPTION
#805 
顺便，我感觉支持GPT API的代码里的data.result = result.replace(/^\n\n/, "");是没必要的？SSE用"data: "分割之后确实带\n\n，但是这会被JSON.parse忽略。
Gemini API每一个chunk都会有`"finishReason": "STOP"`，所以不能用这个判断停止。
Gemini API不会以`data: [DONE]`结束，所以只需要特判split("data: ")之后第一个是空串。
顺便，GPT API应该用`data: [DONE]`判断结束，而不是finish_reason非null。