### PR TITLE
添加新的翻译引擎接口  (deepseek-chat and openai-compatible api)

### DIFF
--- a/addon/chrome/locale/en-US/addon.properties
+++ b/addon/chrome/locale/en-US/addon.properties
@@ -35,6 +35,7 @@ service.openl=OpenL🗝️
 service.tencent=Tencent🗝️
 service.xftrans=Xftrans🗝️
 service.gpt=GPT🗝️
+service.deepseek=DeepSeek🗝️
 service.haici=Haici
 service.bingdict=Bing Dict(en↔zh)🔊
 service.haicidict=Haici Dict(en↔zh)🔊
@@ -79,6 +80,22 @@ service.gpt.dialog.status.available=available
 service.gpt.dialog.status.timeout=timeout
 service.gpt.dialog.status.invalid=secret invalid
 service.gpt.dialog.status.unexpect=fail
+
+service.deepseek.secret.pass=Config
+service.deepseek.secret.fail=Config
+service.deepseek.dialog.title=deepseek Config
+service.deepseek.dialog.url=API
+service.deepseek.dialog.models=Model
+service.deepseek.dialog.temperature=Temp
+service.deepseek.dialog.status=Status
+service.deepseek.dialog.help=help
+service.deepseek.dialog.save=save
+service.deepseek.dialog.close=close
+service.deepseek.dialog.status.load=loading
+service.deepseek.dialog.status.available=available
+service.deepseek.dialog.status.timeout=timeout
+service.deepseek.dialog.status.invalid=secret invalid
+service.deepseek.dialog.status.unexpect=fail
 
 readerpopup.translate.label=Translate
 

--- a/addon/chrome/locale/zh-CN/addon.properties
+++ b/addon/chrome/locale/zh-CN/addon.properties
@@ -35,6 +35,7 @@ service.openl=OpenL🗝️
 service.tencent=腾讯🗝️
 service.xftrans=讯飞🗝️
 service.gpt=GPT🗝️
+service.deepseek=DeepSeek🗝️
 service.haici=海词
 service.bingdict=必应词典(en↔zh)🔊
 service.haicidict=海词词典(en↔zh)🔊
@@ -79,6 +80,22 @@ service.gpt.dialog.status.available=可用
 service.gpt.dialog.status.timeout=请求超时
 service.gpt.dialog.status.invalid=密钥不可用
 service.gpt.dialog.status.unexpect=服务不可用
+
+service.deepseek.secret.pass=配置
+service.deepseek.secret.fail=配置
+service.deepseek.dialog.title=deepseek 配置项
+service.deepseek.dialog.url=接口
+service.deepseek.dialog.models=模型
+service.deepseek.dialog.temperature=温度
+service.deepseek.dialog.status=状态
+service.deepseek.dialog.help=帮助
+service.deepseek.dialog.save=保存
+service.deepseek.dialog.close=关闭
+service.deepseek.dialog.status.load=加载中
+service.deepseek.dialog.status.available=可用
+service.deepseek.dialog.status.timeout=请求超时
+service.deepseek.dialog.status.invalid=密钥不可用
+service.deepseek.dialog.status.unexpect=服务不可用
 
 readerpopup.translate.label=翻译
 

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -40,3 +40,6 @@ pref("__prefsPrefix__.titleColumnMode", "raw");
 pref("__prefsPrefix__.gptUrl", "https://api.openai.com/v1/chat/completions");
 pref("__prefsPrefix__.gptModel", "gpt-3.5-turbo");
 pref("__prefsPrefix__.gptTemperature", "1.0");
+pref("__prefsPrefix__.deepseekUrl", "https://api.deepseek.com/v1/chat/completions");
+pref("__prefsPrefix__.deepseekModel", "deepseek-chat");
+pref("__prefsPrefix__.deepseekTemperature", "1.0");

--- a/src/modules/services.ts
+++ b/src/modules/services.ts
@@ -70,6 +70,9 @@ export class TranslationServices {
     import("./services/gpt").then(
       (e) => (this.gpt = new TranslateTaskRunner(e.gptTranslate))
     );
+    import("./services/deepseek").then(
+      (e) => (this.deepseek = new TranslateTaskRunner(e.deepseekTranslate))
+    );
     import("./services/youdao").then(
       (e) => (this.youdao = new TranslateTaskRunner(e.default))
     );

--- a/src/modules/services/deepseek.ts
+++ b/src/modules/services/deepseek.ts
@@ -1,0 +1,97 @@
+import { TranslateTaskProcessor } from "../../utils/translate";
+import { getPref } from "../../utils/prefs";
+import { getServiceSecret } from "../../utils/translate";
+
+export const deepseekTranslate = <TranslateTaskProcessor>async function (data) {
+  const model = getPref("deepseekModel");
+  const temperature = parseFloat(getPref("deepseekTemperature") as string);
+  const apiUrl = getPref("deepseekUrl");
+  const xhr = await Zotero.HTTP.request(
+    "POST",
+    apiUrl,
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${data.secret}`,
+      },
+      body: JSON.stringify({
+        model: model,
+        messages: [
+          {
+            role: "user",
+            content: `As an academic expert with specialized knowledge in various fields, please provide a proficient and precise translation translation from ${data.langfrom.split("-")[0]} to ${data.langto.split("-")[0]} of the academic text enclosed in 🔤. It is crucial to maintaining the original phrase or sentence and ensure accuracy while utilizing the appropriate language. The text is as follows:  🔤 ${data.raw} 🔤  Please provide the translated result without any additional explanation and remove 🔤.`,
+          },
+        ],
+        temperature: temperature,
+        stream: true,
+      }),
+      responseType: "text",
+      requestObserver: (xmlhttp: XMLHttpRequest) => {
+        let preLength = 0;
+        let result = "";
+        xmlhttp.onprogress = (e: any) => {
+          // Only concatenate the new strings
+          let newResponse = e.target.response.slice(preLength);
+          let dataArray = newResponse.split("data: ");
+
+          for (let data of dataArray) {
+            try {
+              let obj = JSON.parse(data);
+              let choice = obj.choices[0];
+              if (choice.finish_reason) {
+                break;
+              }
+              result += choice.delta.content || "";
+            } catch {
+              continue;
+            }
+          }
+
+          // Clear timeouts caused by stream transfers
+          if (e.target.timeout) {
+            e.target.timeout = 0;
+          }
+
+          // Remove \n\n from the beginning of the data
+          data.result = result.replace(/^\n\n/, "");
+          preLength = e.target.response.length;
+
+          if (data.type === "text") {
+            addon.hooks.onReaderPopupRefresh();
+            addon.hooks.onReaderTabPanelRefresh();
+          }
+        };
+      },
+    }
+  );
+  if (xhr?.status !== 200) {
+    throw `Request error: ${xhr?.status}`;
+  }
+  // data.result = xhr.response.choices[0].message.content.substr(2);
+};
+
+export const updateGPTModel = async function () {
+  const secret = getServiceSecret("gpt");
+  const xhr = await Zotero.HTTP.request(
+    "GET",
+    "https://api.openai.com/v1/models",
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${secret}`,
+      },
+      responseType: "json",
+    }
+  );
+
+  const models = xhr.response.data;
+  const availableModels = [];
+
+  for (const model of models) {
+    if (model.id.includes("gpt")) {
+      availableModels.push(model.id);
+    }
+  }
+
+  return availableModels;
+};

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -270,6 +270,24 @@ export const SERVICES: Readonly<Readonly<TranslateService>[]> = <const>[
     },
   },
   {
+    type: "sentence",
+    id: "deepseek",
+    defaultSecret: "",
+    secretValidator(secret: string) {
+      const status = secret.length === 51 && /^sk-/.test(secret);
+      const empty = secret.length === 0;
+      return {
+        secret,
+        status,
+        info: empty
+          ? "The secret is not set."
+          : status
+          ? "Click the button to check connectivity."
+          : "Ths secret key format is invalid.",
+      };
+    },
+  },
+  {
     type: "word",
     id: "bingdict",
   },

--- a/src/utils/gptModels.ts
+++ b/src/utils/gptModels.ts
@@ -99,22 +99,31 @@ export async function gptStatusCallback(status: boolean) {
             },
           },
           {
-            tag: "select",
+            tag: "input",
             id: "gptModels",
             attributes: {
               "data-bind": "models",
               "data-prop": "value",
+              type: "string",
             },
-            children: [
-              {
-                tag: "option",
-                properties: {
-                  value: selectedModel,
-                  innerHTML: selectedModel,
-                },
-              },
-            ],
           },
+          // {
+          //   tag: "select",
+          //   id: "gptModels",
+          //   attributes: {
+          //     "data-bind": "models",
+          //     "data-prop": "value",
+          //   },
+          //   children: [
+          //     {
+          //       tag: "option",
+          //       properties: {
+          //         value: selectedModel,
+          //         innerHTML: selectedModel,
+          //       },
+          //     },
+          //   ],
+          // },
           {
             tag: "label",
             namespace: "html",


### PR DESCRIPTION
添加了新的翻译引擎
1. Deepseek-chat （接口价格相较于OpenAI便宜数倍）
2. OpenAI 兼容API （可以通过改变URL来使用与OpenAI接口格式相同的API，方便自定义）

Added new translation engines:
1. Deepseek-chat (The deepseek-api price is several times cheaper than OpenAI gpt-3.5-turbo)
2. OpenAI-compatible API (It can use APIs with the same interface format as OpenAI by changing the URL and model_name, making it convenient for customization)