### PR TITLE
✨ feat(gpt): 允许用户指定使用 GPT 翻译的时候是否开启 stream 模式

### DIFF
--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -105,3 +105,5 @@ itemmenu-retranslateAbstract-label=Retranslate Abstract
 
 field-titleTranslation=Title Translation
 field-abstractTranslation=Abstract Translation
+
+status-translating=Translating...

--- a/addon/locale/it-IT/addon.ftl
+++ b/addon/locale/it-IT/addon.ftl
@@ -104,3 +104,5 @@ itemmenu-retranslateAbstract-label=Ritraduci Abstract
 
 field-titleTranslation=Traduzione del titolo
 field-abstractTranslation=Traduzione dell'Abstract
+
+status-translating=Traduzione in corso...

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -104,3 +104,5 @@ itemmenu-retranslateAbstract-label=重新翻译摘要
 
 field-titleTranslation=标题翻译
 field-abstractTranslation=摘要翻译
+
+status-translating=正在翻译...

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -52,6 +52,7 @@ pref(
   "__prefsPrefix__.chatGPT.prompt",
   "As an academic expert with specialized knowledge in various fields, please provide a proficient and precise translation translation from ${langFrom} to ${langTo} of the academic text enclosed in 🔤. It is crucial to maintaining the original phrase or sentence and ensure accuracy while utilizing the appropriate language. The text is as follows:  🔤 ${sourceText} 🔤  Please provide the translated result without any additional explanation and remove 🔤.",
 );
+pref("__prefsPrefix__.chatGPT.stream", true);
 pref("__prefsPrefix__.azureGPT.endPoint", "");
 pref("__prefsPrefix__.azureGPT.model", "");
 pref("__prefsPrefix__.azureGPT.apiVersion", "2023-05-15");
@@ -60,6 +61,7 @@ pref(
   "__prefsPrefix__.azureGPT.prompt",
   "As an academic expert with specialized knowledge in various fields, please provide a proficient and precise translation translation from ${langFrom} to ${langTo} of the academic text enclosed in 🔤. It is crucial to maintaining the original phrase or sentence and ensure accuracy while utilizing the appropriate language. The text is as follows:  🔤 ${sourceText} 🔤  Please provide the translated result without any additional explanation and remove 🔤.",
 );
+pref("__prefsPrefix__.azureGPT.stream", true);
 pref(
   "__prefsPrefix__.gemini.endPoint",
   "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest",

--- a/src/modules/services/gpt.ts
+++ b/src/modules/services/gpt.ts
@@ -1,5 +1,6 @@
 import { TranslateTask, TranslateTaskProcessor } from "../../utils/task";
 import { getPref } from "../../utils/prefs";
+import { getString } from "../../utils/locale";
 
 const gptTranslate = async function (
   apiURL: string,
@@ -7,6 +8,7 @@ const gptTranslate = async function (
   temperature: number,
   prefix: string,
   data: Required<TranslateTask>,
+  stream?: boolean
 ) {
   function transformContent(
     langFrom: string,
@@ -17,6 +19,79 @@ const gptTranslate = async function (
       .replaceAll("${langFrom}", langFrom)
       .replaceAll("${langTo}", langTo)
       .replaceAll("${sourceText}", sourceText);
+  }
+
+  const streamMode = stream ?? true;
+
+  //非流式传输模式下，可能需要等一段时间，所以在请求之前先设置文本为“正在翻译”
+  if (streamMode === false) {
+    data.result = getString('status-translating');
+    addon.hooks.onReaderPopupRefresh();
+    addon.hooks.onReaderTabPanelRefresh();
+  }
+
+  /**
+   * The requestObserver callback, under streaming mode
+   * @param xmlhttp 
+   */
+  const streamCallback = (xmlhttp: XMLHttpRequest) => {
+    let preLength = 0;
+    let result = "";
+    xmlhttp.onprogress = (e: any) => {
+      // Only concatenate the new strings
+      const newResponse = e.target.response.slice(preLength);
+      const dataArray = newResponse.split("data: ");
+
+      for (const data of dataArray) {
+        try {
+          const obj = JSON.parse(data);
+          const choice = obj.choices[0];
+          if (choice.finish_reason) {
+            break;
+          }
+          result += choice.delta.content || "";
+        } catch {
+          continue;
+        }
+      }
+
+      // Clear timeouts caused by stream transfers
+      if (e.target.timeout) {
+        e.target.timeout = 0;
+      }
+
+      // Remove \n\n from the beginning of the data
+      data.result = result.replace(/^\n\n/, "");
+      preLength = e.target.response.length;
+
+      if (data.type === "text") {
+        addon.hooks.onReaderPopupRefresh();
+        addon.hooks.onReaderTabPanelRefresh();
+      }
+    };
+  }
+
+  /**
+   * The requestObserver callback, under non-streaming mode
+   * @param xmlhttp 
+   */
+  const nonStreamCallback = (xmlhttp: XMLHttpRequest) => {
+    // Non-streaming logic: Handle the complete response at once
+    xmlhttp.onload = () => {
+      // console.debug("GPT response received");
+      try {
+        const responseObj = JSON.parse(xmlhttp.responseText);
+        const resultContent = responseObj.choices[0].message.content;
+        data.result = resultContent.replace(/^\n\n/, "");
+      } catch (error) {
+        // throw `Failed to parse response: ${error}`;
+        return;
+      }
+
+      // Trigger UI updates after receiving the full response
+      addon.hooks.onReaderPopupRefresh();
+      addon.hooks.onReaderTabPanelRefresh();
+    };
   }
 
   const xhr = await Zotero.HTTP.request("POST", apiURL, {
@@ -34,44 +109,15 @@ const gptTranslate = async function (
         },
       ],
       temperature: temperature,
-      stream: true,
+      stream: streamMode,
     }),
     responseType: "text",
     requestObserver: (xmlhttp: XMLHttpRequest) => {
-      let preLength = 0;
-      let result = "";
-      xmlhttp.onprogress = (e: any) => {
-        // Only concatenate the new strings
-        const newResponse = e.target.response.slice(preLength);
-        const dataArray = newResponse.split("data: ");
-
-        for (const data of dataArray) {
-          try {
-            const obj = JSON.parse(data);
-            const choice = obj.choices[0];
-            if (choice.finish_reason) {
-              break;
-            }
-            result += choice.delta.content || "";
-          } catch {
-            continue;
-          }
-        }
-
-        // Clear timeouts caused by stream transfers
-        if (e.target.timeout) {
-          e.target.timeout = 0;
-        }
-
-        // Remove \n\n from the beginning of the data
-        data.result = result.replace(/^\n\n/, "");
-        preLength = e.target.response.length;
-
-        if (data.type === "text") {
-          addon.hooks.onReaderPopupRefresh();
-          addon.hooks.onReaderTabPanelRefresh();
-        }
-      };
+      if (streamMode) {
+        streamCallback(xmlhttp);
+      } else {
+        nonStreamCallback(xmlhttp);
+      }
     },
   });
   if (xhr?.status !== 200) {
@@ -84,8 +130,9 @@ export const chatGPT = <TranslateTaskProcessor>async function (data) {
   const apiURL = getPref("chatGPT.endPoint") as string;
   const model = getPref("chatGPT.model") as string;
   const temperature = parseFloat(getPref("chatGPT.temperature") as string);
+  const stream = getPref("chatGPT.stream") as boolean;
 
-  return await gptTranslate(apiURL, model, temperature, "chatGPT", data);
+  return await gptTranslate(apiURL, model, temperature, "chatGPT", data, stream);
 };
 
 export const azureGPT = <TranslateTaskProcessor>async function (data) {
@@ -93,9 +140,11 @@ export const azureGPT = <TranslateTaskProcessor>async function (data) {
   const apiVersion = getPref("azureGPT.apiVersion");
   const model = getPref("azureGPT.model") as string;
   const temperature = parseFloat(getPref("azureGPT.temperature") as string);
+  const stream = getPref("azureGPT.stream") as boolean;
+
   const apiURL = new URL(endPoint);
   apiURL.pathname = `/openai/deployments/${model}/chat/completions`;
   apiURL.search = `api-version=${apiVersion}`;
 
-  return await gptTranslate(apiURL.href, model, temperature, "azureGPT", data);
+  return await gptTranslate(apiURL.href, model, temperature, "azureGPT", data, stream);
 };

--- a/src/modules/settings/gpt.ts
+++ b/src/modules/settings/gpt.ts
@@ -13,6 +13,7 @@ async function gptStatusCallback(
     temperature: parseFloat(getPref(`${prefix}.temperature`) as string),
     prompt: getPref(`${prefix}.prompt`),
     apiVersion: getPref("azureGPT.apiVersion"),
+    stream: getPref(`${prefix}.stream`),
   };
 
   dialog
@@ -133,6 +134,25 @@ async function gptStatusCallback(
               "data-prop": "value",
             },
           },
+          {
+            tag: "label",
+            namespace: "html",
+            attributes: {
+              for: "stream",
+            },
+            properties: {
+              innerHTML: 'Stream',
+            },
+          },
+          {
+            tag: "input",
+            id: "stream",
+            attributes: {
+              type: "checkbox",
+              "data-bind": "stream",
+              "data-prop": "checked",
+            },
+          },
         ],
       },
       false,
@@ -156,6 +176,7 @@ async function gptStatusCallback(
         setPref(`${prefix}.endPoint`, dialogData.endPoint);
         setPref(`${prefix}.model`, dialogData.model);
         setPref(`${prefix}.prompt`, dialogData.prompt);
+        setPref(`${prefix}.stream`, dialogData.stream);
         setPref("azureGPT.apiVersion", dialogData.apiVersion);
       }
       break;


### PR DESCRIPTION
- 在 GPT 的设置选项中增加了一个 `stream` 的 checkbox 选项（默认 true）
- 允许用户关闭 `stream` 模式进行翻译
- 在关闭 stream 模式状态下，会首先将文本框内的文本替换为 "正在翻译..."，此后等消息返回完成后再替换为翻译的结果

效果大致如下：

![image](https://github.com/user-attachments/assets/b4f70a58-5343-490b-b116-0f708789aadc)

![image](https://github.com/user-attachments/assets/c563f611-3d9d-4c9a-8f7d-6845b1e17062)


在 run start 模式下测试了即便，至少本人没发现什么 bug。