### PR TITLE
修改 Gemini API 流式回复为可选项

### DIFF
--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -90,6 +90,7 @@ service-gemini-secret-fail=Config
 service-gemini-dialog-title=Gemini Config
 service-gemini-dialog-endPoint=EndPoint
 service-gemini-dialog-prompt=Prompt
+service-gemini-dialog-stream=Stream
 service-gemini-dialog-save=Save
 service-gemini-dialog-close=Close
 

--- a/addon/locale/it-IT/addon.ftl
+++ b/addon/locale/it-IT/addon.ftl
@@ -89,6 +89,7 @@ service-gemini-secret-fail=Configura
 service-gemini-dialog-title=Configura Gemini
 service-gemini-dialog-endPoint=EndPoint
 service-gemini-dialog-prompt=Prompt
+service-gemini-dialog-stream=Stream
 service-gemini-dialog-save=Salva
 service-gemini-dialog-close=Chiudi
 

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -89,6 +89,7 @@ service-gemini-secret-fail=配置
 service-gemini-dialog-title=Gemini 配置
 service-gemini-dialog-endPoint=接口
 service-gemini-dialog-prompt=Prompt
+service-gemini-dialog-stream=流式输出
 service-gemini-dialog-save=保存
 service-gemini-dialog-close=关闭
 

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -69,6 +69,7 @@ pref(
   "__prefsPrefix__.gemini.prompt",
   "As an academic expert with specialized knowledge in various fields, please provide a proficient and precise translation translation from ${langFrom} to ${langTo} of the academic text enclosed in 🔤. It is crucial to maintaining the original phrase or sentence and ensure accuracy while utilizing the appropriate language. The text is as follows:  🔤 ${sourceText} 🔤  Please provide the translated result without any additional explanation and remove 🔤.",
 );
+pref("__prefsPrefix__.gemini.stream", true);
 pref(
   "__prefsPrefix__.cnkiRegex",
   "(查看名企职位.+?https://dict.cnki.net[a-zA-Z./]+.html?)",

--- a/src/modules/services/gemini.ts
+++ b/src/modules/services/gemini.ts
@@ -17,9 +17,18 @@ const geminiTranslate = async function (
       .replaceAll("${sourceText}", sourceText);
   }
 
+  function getGenContentAPI(data: Required<TranslateTask>) {
+    const stream = getPref("gemini.stream") as boolean;
+    if (stream) {
+      return apiURL + `:streamGenerateContent?alt=sse&key=${data.secret}`;
+    } else {
+      return apiURL + `:generateContent?key=${data.secret}`;
+    }
+  }
+
   const xhr = await Zotero.HTTP.request(
     "POST",
-    apiURL + `:streamGenerateContent?alt=sse&key=${data.secret}`,
+    getGenContentAPI(data),
     {
       headers: {
         "Content-Type": "application/json",

--- a/src/modules/settings/gemini.ts
+++ b/src/modules/settings/gemini.ts
@@ -7,6 +7,7 @@ async function gptStatusCallback(prefix: "gemini", status: boolean) {
   const dialogData: { [key: string | number]: any } = {
     endPoint: getPref(`${prefix}.endPoint`),
     prompt: getPref(`${prefix}.prompt`),
+    stream: getPref(`${prefix}.stream`),
   };
 
   dialog
@@ -20,8 +21,11 @@ async function gptStatusCallback(prefix: "gemini", status: boolean) {
         styles: {
           display: "grid",
           gridTemplateColumns: "1fr 4fr",
+          gridTemplateRows: "auto 1fr auto",
           rowGap: "10px",
           columnGap: "5px",
+          minWidth: "400px",
+          minHeight: "200px",
         },
         children: [
           {
@@ -55,11 +59,31 @@ async function gptStatusCallback(prefix: "gemini", status: boolean) {
             },
           },
           {
-            tag: "input",
+            tag: "textarea",
             id: "prompt",
             attributes: {
               "data-bind": "prompt",
               "data-prop": "value",
+            },
+          },
+
+          {
+            tag: "label",
+            namespace: "html",
+            attributes: {
+              for: "stream",
+            },
+            properties: {
+              innerHTML: getString(`service-${addonPrefix}-dialog-stream`),
+            },
+          },
+          {
+            tag: "input",
+            id: "stream",
+            attributes: {
+              "data-bind": "stream",
+              "data-prop": "checked",
+              type: "checkbox",
             },
           },
         ],
@@ -77,6 +101,7 @@ async function gptStatusCallback(prefix: "gemini", status: boolean) {
       {
         setPref(`${prefix}.endPoint`, dialogData.endPoint);
         setPref(`${prefix}.prompt`, dialogData.prompt);
+        setPref(`${prefix}.stream`, dialogData.stream);
       }
       break;
     default:


### PR DESCRIPTION
此 PR 完善了 #806 中将 Gemini API 默认设置为流式回复的更改。由于 Gemini 1.5 Flash 的响应速度已经足够快，流式回复实现相比非流式反而更慢，本 PR 将流式回复由强制开启更改为可选配置，现在可以在配置中选择使用流式回复或非流式回复。

此外，本 PR 还改进了配置项的样式，使 System Prompt 的查看和编辑更加便捷。

代码已编译通过且与主分支无冲突，可以合并。