### PR TITLE
完善zotero6分支的GPT对gemini模型的支持

### DIFF
--- a/addon/chrome/locale/en-US/addon.properties
+++ b/addon/chrome/locale/en-US/addon.properties
@@ -69,6 +69,7 @@ service.gpt.secret.fail=Config
 service.gpt.dialog.title=GPT Config
 service.gpt.dialog.url=API
 service.gpt.dialog.models=Model
+service.gpt.dialog.isStream=Stream Output
 service.gpt.dialog.temperature=Temp
 service.gpt.dialog.status=Status
 service.gpt.dialog.help=help

--- a/addon/chrome/locale/en-US/addon.properties
+++ b/addon/chrome/locale/en-US/addon.properties
@@ -75,10 +75,10 @@ service.gpt.dialog.help=help
 service.gpt.dialog.save=save
 service.gpt.dialog.close=close
 service.gpt.dialog.status.load=loading
-service.gpt.dialog.status.available=available
+service.gpt.dialog.status.valid=valid secret
 service.gpt.dialog.status.timeout=timeout
-service.gpt.dialog.status.invalid=invalid OpenAI secret
-service.gpt.dialog.status.unexpect=fail
+service.gpt.dialog.status.invalid=invalid secret
+service.gpt.dialog.status.unexpect=unavailable
 
 readerpopup.translate.label=Translate
 

--- a/addon/chrome/locale/zh-CN/addon.properties
+++ b/addon/chrome/locale/zh-CN/addon.properties
@@ -69,6 +69,7 @@ service.gpt.secret.fail=配置
 service.gpt.dialog.title=GPT 配置项
 service.gpt.dialog.url=接口
 service.gpt.dialog.models=模型
+service.gpt.dialog.isStream=流式输出
 service.gpt.dialog.temperature=温度
 service.gpt.dialog.status=状态
 service.gpt.dialog.help=帮助

--- a/addon/chrome/locale/zh-CN/addon.properties
+++ b/addon/chrome/locale/zh-CN/addon.properties
@@ -75,10 +75,10 @@ service.gpt.dialog.help=帮助
 service.gpt.dialog.save=保存
 service.gpt.dialog.close=关闭
 service.gpt.dialog.status.load=加载中
-service.gpt.dialog.status.available=可用
+service.gpt.dialog.status.valid=有效密钥
 service.gpt.dialog.status.timeout=请求超时
-service.gpt.dialog.status.invalid=无效的OpenAI密钥
-service.gpt.dialog.status.unexpect=服务不可用
+service.gpt.dialog.status.invalid=无效密钥
+service.gpt.dialog.status.unexpect=不可用
 
 readerpopup.translate.label=翻译
 

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -39,4 +39,5 @@ pref("__prefsPrefix__.extraEngines", "");
 pref("__prefsPrefix__.titleColumnMode", "raw");
 pref("__prefsPrefix__.gptUrl", "https://api.openai.com/v1/chat/completions");
 pref("__prefsPrefix__.gptModel", "gpt-3.5-turbo");
+pref("__prefsPrefix__.gptIsStream", "true");
 pref("__prefsPrefix__.gptTemperature", "1.0");

--- a/src/modules/services/gpt.ts
+++ b/src/modules/services/gpt.ts
@@ -38,9 +38,6 @@ export const gptTranslate = <TranslateTaskProcessor>async function (data) {
             try {
               let obj = JSON.parse(data);
               let choice = obj.choices[0];
-              if (choice.finish_reason) {
-                break;
-              }
               result += choice.delta.content || "";
             } catch {
               continue;

--- a/src/modules/services/gpt.ts
+++ b/src/modules/services/gpt.ts
@@ -95,3 +95,19 @@ export const updateGPTModel = async function () {
 
   return availableModels;
 };
+
+export const authGPT = async function () {
+  const secret = getServiceSecret("gpt");
+  const apiUrl = getPref("gptUrl") as string ?? "https://api.openai.com/v1/chat/completions";
+  const xhr = await Zotero.HTTP.request(
+    "GET",
+    apiUrl.replace("/chat/completions", "/models"),
+    {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${secret}`,
+      },
+      responseType: "json",
+    }
+  );
+};

--- a/src/utils/gptModels.ts
+++ b/src/utils/gptModels.ts
@@ -1,6 +1,7 @@
 import { getPref, setPref } from "./prefs";
 import { getString } from "./locale";
 import { updateGPTModel } from "../modules/services/gpt";
+import { authGPT } from "../modules/services/gpt";
 
 export async function gptStatusCallback(status: boolean) {
   const selectedModel = getPref("gptModel");
@@ -13,29 +14,9 @@ export async function gptStatusCallback(status: boolean) {
       const doc = dialog.window.document;
 
       try {
-        const models = await updateGPTModel();
-        // Due to an unknown bug with Zotero 7, the `<select>` element cannot be properly rendered.
-        // Toolkit uses a workaround to render the element, so please do not touch the original element and just replace its inner `<option>` elements.
-        // See https://groups.google.com/g/zotero-dev/c/iG763ZlWQ_U
-        const modelsSelect = doc.querySelector("#gptModels")!;
-        modelsSelect.innerHTML = "";
-        ztoolkit.UI.appendElement(
-          {
-            tag: "fragment",
-            children: models.map((model: string) => ({
-              tag: "option",
-              properties: {
-                value: model,
-                innerHTML: model,
-                selected: model === selectedModel,
-              },
-            })),
-          },
-          modelsSelect
-        );
-
+        await authGPT();
         doc.querySelector("#gptStatus")!.innerHTML = getString(
-          "service.gpt.dialog.status.available"
+          "service.gpt.dialog.status.valid"
         );
       } catch (error: any) {
         const HTTP = Zotero.HTTP;

--- a/src/utils/gptModels.ts
+++ b/src/utils/gptModels.ts
@@ -10,6 +10,7 @@ export async function gptStatusCallback(status: boolean) {
     url: getPref("gptUrl"),
     models: getPref("gptModel"),
     temperature: parseFloat(getPref("gptTemperature") as string),
+    isStream: getPref("gptIsStream"),
     loadCallback: async () => {
       const doc = dialog.window.document;
 
@@ -51,6 +52,7 @@ export async function gptStatusCallback(status: boolean) {
           columnGap: "5px",
         },
         children: [
+          // URL
           {
             tag: "label",
             namespace: "html",
@@ -70,6 +72,7 @@ export async function gptStatusCallback(status: boolean) {
               type: "string",
             },
           },
+          // Models
           {
             tag: "label",
             namespace: "html",
@@ -89,6 +92,43 @@ export async function gptStatusCallback(status: boolean) {
               type: "string",
             },
           },
+          // Stream Output
+          {
+            tag: "label",
+            namespace: "html",
+            attributes: {
+              for: "isStream",
+            },
+            properties: {
+              innerHTML: getString("service.gpt.dialog.isStream"),
+            },
+          },
+          {
+            tag: "select",
+            id: "gptIsStream",
+            attributes: {
+              "data-bind": "isStream",
+              "data-prop": "value",
+              type: "string",
+            },
+            children: [
+              {
+                tag: "option",
+                properties: {
+                  value: "true",
+                  innerHTML: "true",
+                },
+              },
+              {
+                tag: "option",
+                properties: {
+                  value: "false",
+                  innerHTML: "false",
+                },
+              },
+            ],
+          },
+          // temperature
           {
             tag: "label",
             namespace: "html",
@@ -179,6 +219,7 @@ export async function gptStatusCallback(status: boolean) {
 
         setPref("gptUrl", dialogData.url)
         setPref("gptModel", dialogData.models);
+        setPref("gptIsStream", dialogData.isStream);
       }
       break;
     default:


### PR DESCRIPTION
zotero6分支的虽然可以用one-hub或one-api等中转层，以在GPT配置项使用gemini模型，但还需要zotero-pdf-translate进行类似于 #806 #985 的修改

close #756 