### PR TITLE
feat: add stream output select for gemini

### DIFF
--- a/addon/chrome/locale/en-US/addon.properties
+++ b/addon/chrome/locale/en-US/addon.properties
@@ -69,6 +69,7 @@ service.gpt.secret.fail=Config
 service.gpt.dialog.title=GPT Config
 service.gpt.dialog.url=API
 service.gpt.dialog.models=Model
+service.gpt.dialog.isStream=Stream Output
 service.gpt.dialog.temperature=Temp
 service.gpt.dialog.status=Status
 service.gpt.dialog.help=help

--- a/addon/chrome/locale/zh-CN/addon.properties
+++ b/addon/chrome/locale/zh-CN/addon.properties
@@ -69,6 +69,7 @@ service.gpt.secret.fail=配置
 service.gpt.dialog.title=GPT 配置项
 service.gpt.dialog.url=接口
 service.gpt.dialog.models=模型
+service.gpt.dialog.isStream=流式输出
 service.gpt.dialog.temperature=温度
 service.gpt.dialog.status=状态
 service.gpt.dialog.help=帮助

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -39,4 +39,5 @@ pref("__prefsPrefix__.extraEngines", "");
 pref("__prefsPrefix__.titleColumnMode", "raw");
 pref("__prefsPrefix__.gptUrl", "https://api.openai.com/v1/chat/completions");
 pref("__prefsPrefix__.gptModel", "gpt-3.5-turbo");
+pref("__prefsPrefix__.gptIsStream", "true");
 pref("__prefsPrefix__.gptTemperature", "1.0");

--- a/src/modules/services/gpt.ts
+++ b/src/modules/services/gpt.ts
@@ -6,6 +6,8 @@ export const gptTranslate = <TranslateTaskProcessor>async function (data) {
   const model = getPref("gptModel");
   const temperature = parseFloat(getPref("gptTemperature") as string);
   const apiUrl = getPref("gptUrl");
+  const isStream = getPref("gptIsStream");
+
   const xhr = await Zotero.HTTP.request(
     "POST",
     apiUrl,
@@ -23,51 +25,55 @@ export const gptTranslate = <TranslateTaskProcessor>async function (data) {
           },
         ],
         temperature: temperature,
-        stream: true,
+        stream: isStream === "true",
       }),
-      responseType: "text",
-      requestObserver: (xmlhttp: XMLHttpRequest) => {
-        let preLength = 0;
-        let result = "";
-        xmlhttp.onprogress = (e: any) => {
-          // Only concatenate the new strings
-          let newResponse = e.target.response.slice(preLength);
-          let dataArray = newResponse.split("data: ");
+      
+      responseType: isStream === "true" ? "text" : "json",
+      ...(isStream === "true" && {
+        requestObserver: (xmlhttp: XMLHttpRequest) => {
+          let preLength = 0;
+          let result = "";
+          xmlhttp.onprogress = (e: any) => {
+            // Only concatenate the new strings
+            let newResponse = e.target.response.slice(preLength);
+            let dataArray = newResponse.split("data: ");
 
-          for (let data of dataArray) {
-            try {
-              let obj = JSON.parse(data);
-              let choice = obj.choices[0];
-              if (choice.finish_reason) {
-                break;
+            for (let data of dataArray) {
+              try {
+                let obj = JSON.parse(data);
+                let choice = obj.choices[0];
+                result += choice.delta.content || "";
+              } catch {
+                continue;
               }
-              result += choice.delta.content || "";
-            } catch {
-              continue;
             }
-          }
 
-          // Clear timeouts caused by stream transfers
-          if (e.target.timeout) {
-            e.target.timeout = 0;
-          }
+            // Clear timeouts caused by stream transfers
+            if (e.target.timeout) {
+              e.target.timeout = 0;
+            }
 
-          // Remove \n\n from the beginning of the data
-          data.result = result.replace(/^\n\n/, "");
-          preLength = e.target.response.length;
+            // Remove \n\n from the beginning of the data
+            data.result = result.replace(/^\n\n/, "");
+            preLength = e.target.response.length;
 
-          if (data.type === "text") {
-            addon.hooks.onReaderPopupRefresh();
-            addon.hooks.onReaderTabPanelRefresh();
-          }
-        };
-      },
+            if (data.type === "text") {
+              addon.hooks.onReaderPopupRefresh();
+              addon.hooks.onReaderTabPanelRefresh();
+            }
+          };
+        }
+      })
     }
   );
+
   if (xhr?.status !== 200) {
     throw `Request error: ${xhr?.status}`;
   }
-  // data.result = xhr.response.choices[0].message.content.substr(2);
+
+  if (isStream === "false") {
+    data.result = xhr.response.choices[0].message.content;
+  }
 };
 
 export const updateGPTModel = async function () {

--- a/src/utils/gptModels.ts
+++ b/src/utils/gptModels.ts
@@ -10,6 +10,7 @@ export async function gptStatusCallback(status: boolean) {
     url: getPref("gptUrl"),
     models: getPref("gptModel"),
     temperature: parseFloat(getPref("gptTemperature") as string),
+    isStream: getPref("gptIsStream"),
     loadCallback: async () => {
       const doc = dialog.window.document;
 
@@ -51,6 +52,7 @@ export async function gptStatusCallback(status: boolean) {
           columnGap: "5px",
         },
         children: [
+          // URL
           {
             tag: "label",
             namespace: "html",
@@ -70,6 +72,7 @@ export async function gptStatusCallback(status: boolean) {
               type: "string",
             },
           },
+          // Models
           {
             tag: "label",
             namespace: "html",
@@ -89,6 +92,43 @@ export async function gptStatusCallback(status: boolean) {
               type: "string",
             },
           },
+          // Stream Output
+          {
+            tag: "label",
+            namespace: "html",
+            attributes: {
+              for: "isStream",
+            },
+            properties: {
+              innerHTML: getString("service.gpt.dialog.isStream"),
+            },
+          },
+          {
+            tag: "select",
+            id: "gptIsStream",
+            attributes: {
+              "data-bind": "isStream",
+              "data-prop": "value",
+              type: "string",
+            },
+            children: [
+              {
+                tag: "option",
+                properties: {
+                  value: "true",
+                  innerHTML: "true",
+                },
+              },
+              {
+                tag: "option",
+                properties: {
+                  value: "false",
+                  innerHTML: "false",
+                },
+              },
+            ],
+          },
+          // temperature
           {
             tag: "label",
             namespace: "html",
@@ -179,6 +219,7 @@ export async function gptStatusCallback(status: boolean) {
 
         setPref("gptUrl", dialogData.url)
         setPref("gptModel", dialogData.models);
+        setPref("gptIsStream", dialogData.isStream);
       }
       break;
     default:


### PR DESCRIPTION
完善zotero6分支的GPT对gemini模型的支持。  
zotero6分支的虽然可以用one-hub或one-api等中转层，以在GPT配置项使用gemini模型，但还需要zotero-pdf-translate进行类似于 #806 #985 的修改

对应issue #756 