### PR TITLE
chore(eslint): migrate to v9.x

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 pref("__prefsPrefix__.enableAuto", true);
 pref("__prefsPrefix__.enableDict", true);
 pref("__prefsPrefix__.enablePopup", true);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,4 +44,19 @@ export default tseslint.config(
       "@typescript-eslint/no-non-null-assertion": "off",
     },
   },
+  {
+    // allow to use the `document` global directly in CEs
+    files: ["src/elements/*.ts"],
+    rules: {
+      "no-restricted-globals": [
+        "error",
+        { message: "Use `Zotero.getMainWindow()` instead.", name: "window" },
+        {
+          message: "Use `Zotero.getActiveZoteroPane()` instead.",
+          name: "ZoteroPane",
+        },
+        "Zotero_Tabs",
+      ],
+    },
+  },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,12 +45,11 @@ export default tseslint.config(
     },
   },
   {
-    // allow to use the `document` global directly in CEs
+    // allow to use the `document` and `window` globals directly in CEs
     files: ["src/elements/*.ts"],
     rules: {
       "no-restricted-globals": [
         "error",
-        { message: "Use `Zotero.getMainWindow()` instead.", name: "window" },
         {
           message: "Use `Zotero.getActiveZoteroPane()` instead.",
           name: "ZoteroPane",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,47 @@
+// @ts-check Let TS check this config file
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: ["build/**", "dist/**", "node_modules/**", "scripts/"],
+  },
+  {
+    files: ["**/*.ts"],
+    extends: [eslint.configs.recommended, ...tseslint.configs.recommended],
+    rules: {
+      "no-restricted-globals": [
+        "error",
+        { message: "Use `Zotero.getMainWindow()` instead.", name: "window" },
+        {
+          message: "Use `Zotero.getMainWindow().document` instead.",
+          name: "document",
+        },
+        {
+          message: "Use `Zotero.getActiveZoteroPane()` instead.",
+          name: "ZoteroPane",
+        },
+        "Zotero_Tabs",
+      ],
+
+      "@typescript-eslint/ban-ts-comment": [
+        "warn",
+        {
+          "ts-expect-error": "allow-with-description",
+          "ts-ignore": "allow-with-description",
+          "ts-nocheck": "allow-with-description",
+          "ts-check": "allow-with-description",
+        },
+      ],
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-explicit-any": [
+        "off",
+        {
+          ignoreRestArgs: true,
+        },
+      ],
+      "@typescript-eslint/no-non-null-assertion": "off",
+    },
+  },
+);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "zotero-plugin serve",
     "build": "tsc --noEmit && zotero-plugin build",
     "release": "zotero-plugin release",
-    "lint": "prettier --write . && eslint . --ext .ts --fix",
+    "lint": "prettier --write . && eslint . --fix",
     "test": "echo \"Error: no test specified\" && exit 1",
     "update-deps": "npm update --save"
   },
@@ -48,55 +48,6 @@
     "typescript-eslint": "^8.15.0",
     "zotero-plugin-scaffold": "^0.1.7",
     "zotero-types": "^3.0.2"
-  },
-  "eslintConfig": {
-    "env": {
-      "browser": true,
-      "es2021": true
-    },
-    "root": true,
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "prettier"
-    ],
-    "overrides": [],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "ecmaVersion": "latest",
-      "sourceType": "module"
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "rules": {
-      "@typescript-eslint/ban-ts-comment": [
-        "warn",
-        {
-          "ts-expect-error": "allow-with-description",
-          "ts-ignore": "allow-with-description",
-          "ts-nocheck": "allow-with-description",
-          "ts-check": "allow-with-description"
-        }
-      ],
-      "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-explicit-any": [
-        "off",
-        {
-          "ignoreRestArgs": true
-        }
-      ],
-      "@typescript-eslint/no-non-null-assertion": "off"
-    },
-    "ignorePatterns": [
-      "**/build/**",
-      "**/logs/**",
-      "**/dist/**",
-      "**/node_modules/**",
-      "**/scripts/**",
-      "**/*.js",
-      "**/*.bak"
-    ]
   },
   "prettier": {
     "printWidth": 80,

--- a/src/elements/base.ts
+++ b/src/elements/base.ts
@@ -15,20 +15,19 @@ export class PluginCEBase extends XULElementBase {
     // Following the connectedCallback from XULElementBase
     let content: Node = this.content;
     if (content) {
-      content = document.importNode(content, true);
+      content = Zotero.getMainWindow().document.importNode(content, true);
       this.shadowRoot?.append(content);
     }
 
     MozXULElement.insertFTLIfNeeded("branding/brand.ftl");
     MozXULElement.insertFTLIfNeeded("zotero.ftl");
-    if (document.l10n && this.shadowRoot) {
-      document.l10n.connectRoot(this.shadowRoot);
+    const documentL10n = Zotero.getMainWindow().document.l10n;
+    if (documentL10n && this.shadowRoot) {
+      documentL10n.connectRoot(this.shadowRoot);
     }
 
-    // @ts-ignore
-    window.addEventListener("unload", this._handleWindowUnload);
+    Zotero.getMainWindow().addEventListener("unload", this._handleWindowUnload);
 
-    // @ts-ignore
     this.initialized = true;
     this.init();
   }

--- a/src/elements/base.ts
+++ b/src/elements/base.ts
@@ -15,15 +15,14 @@ export class PluginCEBase extends XULElementBase {
     // Following the connectedCallback from XULElementBase
     let content: Node = this.content;
     if (content) {
-      content = Zotero.getMainWindow().document.importNode(content, true);
+      content = document.importNode(content, true);
       this.shadowRoot?.append(content);
     }
 
     MozXULElement.insertFTLIfNeeded("branding/brand.ftl");
     MozXULElement.insertFTLIfNeeded("zotero.ftl");
-    const documentL10n = Zotero.getMainWindow().document.l10n;
-    if (documentL10n && this.shadowRoot) {
-      documentL10n.connectRoot(this.shadowRoot);
+    if (document.l10n && this.shadowRoot) {
+      document.l10n.connectRoot(this.shadowRoot);
     }
 
     Zotero.getMainWindow().addEventListener("unload", this._handleWindowUnload);

--- a/src/elements/base.ts
+++ b/src/elements/base.ts
@@ -25,7 +25,7 @@ export class PluginCEBase extends XULElementBase {
       document.l10n.connectRoot(this.shadowRoot);
     }
 
-    Zotero.getMainWindow().addEventListener("unload", this._handleWindowUnload);
+    window.addEventListener("unload", this._handleWindowUnload);
 
     this.initialized = true;
     this.init();

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -63,7 +63,7 @@ async function onStartup() {
 
   registerReaderTabPanel();
 
-  await onMainWindowLoad(window);
+  await onMainWindowLoad(Zotero.getMainWindow());
 }
 
 async function onMainWindowLoad(win: Window): Promise<void> {
@@ -154,7 +154,8 @@ function onShortcuts(type: string) {
     case "library":
       {
         addon.hooks.onTranslateInBatch(
-          ZoteroPane.getSelectedItems(true)
+          Zotero.getActiveZoteroPane()
+            .getSelectedItems(true)
             .map((id) => addTranslateTitleTask(id, true))
             .filter((task) => task) as TranslateTask[],
           { noDisplay: true },

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -63,7 +63,9 @@ async function onStartup() {
 
   registerReaderTabPanel();
 
-  await onMainWindowLoad(Zotero.getMainWindow());
+  await Promise.all(
+    Zotero.getMainWindows().map((win) => onMainWindowLoad(win)),
+  );
 }
 
 async function onMainWindowLoad(win: Window): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,6 @@ const basicTool = new BasicTool();
 if (!basicTool.getGlobal("Zotero")[config.addonInstance]) {
   // Set global variables
   _globalThis.Zotero = basicTool.getGlobal("Zotero");
-  defineGlobal("window");
-  defineGlobal("document");
-  defineGlobal("ZoteroPane");
-  defineGlobal("Zotero_Tabs");
-  defineGlobal("ZoteroContextPane");
   defineGlobal("crypto");
   defineGlobal("TextEncoder");
   _globalThis.addon = new Addon();

--- a/src/modules/fields.ts
+++ b/src/modules/fields.ts
@@ -9,6 +9,7 @@ function registerCustomFields() {
       unformatted: boolean,
       includeBaseMapped: boolean,
       item: Zotero.Item,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
       original: Function,
     ) => {
       return ztoolkit.ExtraField.getExtraField(item, field) || "";
@@ -23,6 +24,7 @@ function registerCustomFields() {
       unformatted: boolean,
       includeBaseMapped: boolean,
       item: Zotero.Item,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
       original: Function,
     ) => {
       return ztoolkit.ExtraField.getExtraField(item, field) || "";

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -12,13 +12,14 @@ export function registerMenu() {
   ztoolkit.Menu.register("item", {
     tag: "menuseparator",
   });
-  getPref("showItemMenuTitleTranslation") &&
+  if (getPref("showItemMenuTitleTranslation")) {
     ztoolkit.Menu.register("item", {
       tag: "menuitem",
       label: getString("itemmenu-translateTitle-label"),
       commandListener: (ev) => {
         addon.hooks.onTranslateInBatch(
-          ZoteroPane.getSelectedItems(true)
+          Zotero.getActiveZoteroPane()
+            .getSelectedItems(true)
             .map((id) => addTranslateTitleTask(id, true))
             .filter((task) => task) as TranslateTask[],
           { noDisplay: true },
@@ -26,14 +27,16 @@ export function registerMenu() {
       },
       icon: menuIcon,
     });
+  }
 
-  getPref("showItemMenuAbstractTranslation") &&
+  if (getPref("showItemMenuAbstractTranslation")) {
     ztoolkit.Menu.register("item", {
       tag: "menuitem",
       label: getString("itemmenu-translateAbstract-label"),
       commandListener: (ev) => {
         addon.hooks.onTranslateInBatch(
-          ZoteroPane.getSelectedItems(true)
+          Zotero.getActiveZoteroPane()
+            .getSelectedItems(true)
             .map((id) => addTranslateAbstractTask(id, true))
             .filter((task) => task) as TranslateTask[],
           { noDisplay: true },
@@ -41,4 +44,5 @@ export function registerMenu() {
       },
       icon: menuIcon,
     });
+  }
 }

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -86,7 +86,11 @@ export function updateReaderPopup() {
   textarea.style.lineHeight = `${
     Number(getPref("lineHeight")) * Number(getPref("fontSize"))
   }px`;
-  updateHidden(addToNoteButton, !ZoteroContextPane.activeEditor);
+
+  updateHidden(
+    addToNoteButton,
+    !Zotero.getMainWindow().ZoteroContextPane.activeEditor,
+  );
 
   updatePopupSize(popup, textarea);
 }
@@ -103,6 +107,8 @@ export function buildReaderPopup(
     `${config.addonRef}-prefix`,
     `${config.addonRef}-${reader._instanceID}`,
   );
+
+  const ZoteroContextPane = Zotero.getMainWindow().ZoteroContextPane;
 
   const colors = popup.querySelector(".colors") as HTMLDivElement;
   colors.style.width = "100%";

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -295,7 +295,7 @@ export function buildReaderPopup(
                 } else {
                   annotation.comment = task.result;
                 }
-                // @ts-ignore should be fixed in the zotero types
+                // @ts-ignore should be fixed in the zotero-types
                 reader._addToNote([annotation]);
               },
             },

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -289,7 +289,7 @@ export function buildReaderPopup(
                 } else {
                   annotation.comment = task.result;
                 }
-                // @ts-ignore should be fixed in the zotero-types
+                // @ts-ignore should be fixed in the zotero types
                 reader._addToNote([annotation]);
               },
             },

--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -203,12 +203,13 @@ export function registerPrompt() {
       `,
         );
         const subContainers: HTMLDivElement[] = [];
+        const doc = Zotero.getMainWindow().document;
         [
           ["raw", rawText, [".", "?", "!"]],
           ["result", resultText, ["?", "!", "！", "。", "？"]],
         ].forEach((args: any[]) => {
           const [className, text, dividers] = args;
-          const subContainer = ztoolkit.UI.createElement(document, "div", {
+          const subContainer = ztoolkit.UI.createElement(doc, "div", {
             styles: {
               padding: ".5em",
               border: "1px solid #eee",
@@ -240,7 +241,7 @@ export function registerPrompt() {
         });
 
         const size = 5;
-        const resizer = ztoolkit.UI.createElement(document, "div", {
+        const resizer = ztoolkit.UI.createElement(doc, "div", {
           styles: {
             height: direction == "row" ? "100%" : `${size}px`,
             width: direction == "column" ? "100%" : `${size}px`,
@@ -267,8 +268,8 @@ export function registerPrompt() {
           const rect = subContainers[1].getBoundingClientRect();
           h = rect.height;
           w = rect.width;
-          document.addEventListener("mousemove", mouseMoveHandler);
-          document.addEventListener("mouseup", mouseUpHandler);
+          doc.addEventListener("mousemove", mouseMoveHandler);
+          doc.addEventListener("mouseup", mouseUpHandler);
         };
         const mouseMoveHandler = function (e: MouseEvent) {
           const dy = e.clientY - y;
@@ -289,8 +290,8 @@ export function registerPrompt() {
               .querySelectorAll("span")
               .forEach((e: HTMLSpanElement) => (e.style.display = ""));
           });
-          document.removeEventListener("mousemove", mouseMoveHandler);
-          document.removeEventListener("mouseup", mouseUpHandler);
+          doc.removeEventListener("mousemove", mouseMoveHandler);
+          doc.removeEventListener("mouseup", mouseUpHandler);
         };
         resizer.addEventListener("mousedown", mouseDownHandler);
 

--- a/src/modules/services/baidu.ts
+++ b/src/modules/services/baidu.ts
@@ -13,7 +13,6 @@ export default <TranslateTaskProcessor>async function (data) {
     appid + data.raw + salt + key,
     false,
   );
-  `from=${data.langfrom.split("-")[0]}&to=${data.langto.split("-")[0]}`;
 
   // Request
   const xhr = await Zotero.HTTP.request(

--- a/src/modules/services/baidufield.ts
+++ b/src/modules/services/baidufield.ts
@@ -10,7 +10,6 @@ export default <TranslateTaskProcessor>async function (data) {
     appid + data.raw + salt + domain + key,
     false,
   );
-  `from=${data.langfrom.split("-")[0]}&to=${data.langto.split("-")[0]}`;
   const xhr = await Zotero.HTTP.request(
     "GET",
     `http://api.fanyi.baidu.com/api/trans/vip/fieldtranslate?q=${encodeURIComponent(

--- a/src/modules/services/google.ts
+++ b/src/modules/services/google.ts
@@ -19,6 +19,8 @@ async function _google(url: string, data: Required<TranslateTask>) {
 
     let e, f, g;
 
+    // disable the eslint, as the code is copied from google translate
+    /* eslint-disable */
     for (e = [], f = 0, g = 0; g < a.length; g++) {
       let m = a.charCodeAt(g);
       128 > m
@@ -42,6 +44,7 @@ async function _google(url: string, data: Required<TranslateTask>) {
     a ^= b1 || 0;
     0 > a && (a = (a & 2147483647) + 2147483648);
     a %= 1e6;
+    /* eslint-enable */
     return a.toString() + jd + (a ^ b);
   }
 
@@ -50,9 +53,9 @@ async function _google(url: string, data: Required<TranslateTask>) {
     const Yb = "+";
     let d;
     for (let c = 0; c < b.length - 2; c += 3) {
-      (d = b.charAt(c + 2)),
-        (d = d >= t ? d.charCodeAt(0) - 87 : Number(d)),
-        (d = b.charAt(c + 1) == Yb ? a >>> d : a << d);
+      d = b.charAt(c + 2);
+      d = d >= t ? d.charCodeAt(0) - 87 : Number(d);
+      d = b.charAt(c + 1) == Yb ? a >>> d : a << d;
       a = b.charAt(c) == Yb ? (a + d) & 4294967295 : a ^ d;
     }
     return a;

--- a/src/modules/services/webliodict.ts
+++ b/src/modules/services/webliodict.ts
@@ -31,11 +31,13 @@ export default <TranslateTaskProcessor>async function (data) {
     (e: Element) => translations.push(process(e)),
   );
 
-  (Array.from(doc.querySelectorAll(".intrst")) as Element[])
-    .map((e: Element) => e.querySelector("tr"))
-    .forEach((e) => {
-      e && translations.push(process(e));
-    });
+  for (const e of doc.querySelectorAll<Element>(".intrst")) {
+    const tableRow = e.querySelector<HTMLTableRowElement>("tr");
+    if (tableRow) {
+      translations.push(process(tableRow));
+    }
+  }
+
   data.result = translations
     .filter((t) => t)
     .map((t) => t.join(":"))

--- a/src/modules/settings/niutrans.ts
+++ b/src/modules/settings/niutrans.ts
@@ -246,7 +246,7 @@ export async function niutransStatusCallback(status: boolean) {
           dialogData.password,
         );
         if (!loginFlag) {
-          window.alert(loginErrorMessage);
+          Zotero.getMainWindow().alert(loginErrorMessage);
         }
         await niutransStatusCallback(loginFlag);
       }

--- a/src/modules/shortcuts.ts
+++ b/src/modules/shortcuts.ts
@@ -2,7 +2,9 @@ export function registerShortcuts() {
   ztoolkit.Keyboard.register((ev, data) => {
     if (data.type === "keyup" && data.keyboard) {
       if (data.keyboard.equals("accel,T")) {
-        addon.hooks.onShortcuts(Zotero_Tabs.selectedType);
+        addon.hooks.onShortcuts(
+          Zotero.getMainWindow().Zotero_Tabs.selectedType,
+        );
       }
     }
     if (data.type === "keydown") {

--- a/src/modules/tabpanel.ts
+++ b/src/modules/tabpanel.ts
@@ -48,7 +48,7 @@ export function registerReaderTabPanel() {
         onClick: ({ body }) => {
           const details = body.closest("item-details");
           onUpdateHeight({ body });
-          // @ts-ignore
+          // @ts-ignore 'item-details' is a custom element on Zotero
           details.scrollToPane(paneKey);
         },
       },
@@ -255,7 +255,7 @@ function onItemChange({
 }
 
 function updateExtraPanel(container: HTMLElement | Document) {
-  let lastTask = getLastTranslateTask();
+  const lastTask = getLastTranslateTask();
   const panel = container.querySelector(
     "translator-plugin-panel",
   ) as TranslatorPanel;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,6 @@
 import { franc } from "franc";
-import ISO6393_3_TO_2 = require("iso639-js/alpha3to2mapping.json");
-import ISO6393_MACRO_LANGS = require("iso639-js/reference/iso639-3-macrolanguages.json");
+import ISO6393_3_TO_2 from "iso639-js/alpha3to2mapping.json";
+import ISO6393_MACRO_LANGS from "iso639-js/reference/iso639-3-macrolanguages.json";
 
 interface TranslateService {
   type: "word" | "sentence";
@@ -1602,15 +1602,13 @@ export const LANG_CODE = <const>[
   },
 ];
 
-const MACRO_LANG_MAP = Object.keys(ISO6393_MACRO_LANGS).reduce(
-  (prev, curr) => {
-    ISO6393_MACRO_LANGS[curr as keyof typeof ISO6393_MACRO_LANGS].forEach(
-      (macroLang) => {
-        Object.keys(macroLang).forEach((macroLangCode) => {
-          prev[macroLangCode] = curr;
-        });
-      },
-    );
+const MACRO_LANG_MAP = Object.entries(ISO6393_MACRO_LANGS).reduce(
+  (prev, [curr, items]) => {
+    items.forEach((macroLang) => {
+      Object.keys(macroLang).forEach((macroLangCode) => {
+        prev[macroLangCode] = curr;
+      });
+    });
     return prev;
   },
   {} as Record<string, string>,

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -139,6 +139,7 @@ export function addTranslateTask(
   const addon = Zotero[config.addonInstance] as Addon;
   type = type || "text";
   // Filter raw string
+
   // eslint-disable-next-line no-control-regex
   raw = raw.replace(/[\u0000-\u001F\u007F-\u009F]/gu, " ").normalize("NFKC");
 
@@ -374,7 +375,9 @@ export function autoDetectLanguage(item: Zotero.Item | null) {
         if (inferredLanguage) {
           // Update language field so that it can be used in the future
           itemLanguage = inferredLanguage;
-          topItem.isRegularItem() && topItem.setField("language", fromLanguage);
+          if (topItem.isRegularItem()) {
+            topItem.setField("language", fromLanguage);
+          }
         }
       }
       if (itemLanguage && ![fromLanguage, toLanguage].includes(itemLanguage)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
     "module": "commonjs",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "target": "ES2016",
+    // esModuleInterop is required for importing CommonJS modules with native ESM
+    // used by 'src/utils/config.ts'
+    "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -2,7 +2,6 @@ declare const _globalThis: {
   [key: string]: any;
   Zotero: _ZoteroTypes.Zotero;
   ZoteroPane: _ZoteroTypes.ZoteroPane;
-  Zotero_Tabs: typeof Zotero_Tabs;
   ZoteroContextPane: typeof ZoteroContextPane;
   window: Window;
   document: Document;
@@ -35,6 +34,8 @@ declare class XULElementBase extends HTMLElement {
     oldValue: string,
     newValue: string,
   ): void;
+  _handleWindowUnload(): void;
+  initialized: boolean = false;
   static get observedAttributes(): string[];
 }
 

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -1,10 +1,6 @@
 declare const _globalThis: {
   [key: string]: any;
   Zotero: _ZoteroTypes.Zotero;
-  ZoteroPane: _ZoteroTypes.ZoteroPane;
-  ZoteroContextPane: typeof ZoteroContextPane;
-  window: Window;
-  document: Document;
   crypto: Crypto;
   TextEncoder: typeof TextEncoder;
   ztoolkit: ZToolkit;


### PR DESCRIPTION
Migrate the configuration of eslint to v9.x. Check: https://eslint.org/docs/latest/use/migrate-to-9.0.0

Run `npm run lint` to check the migration.
