### PR TITLE
fix: odd menu separator even if disable item menu settings

### DIFF
--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -9,7 +9,10 @@ import {
 
 export function registerMenu() {
   const menuIcon = `chrome://${config.addonRef}/content/icons/favicon.png`;
-  if (getPref("showItemMenuTitleTranslation") || getPref("showItemMenuAbstractTranslation")) {
+  if (
+    getPref("showItemMenuTitleTranslation") ||
+    getPref("showItemMenuAbstractTranslation")
+  ) {
     ztoolkit.Menu.register("item", {
       tag: "menuseparator",
     });

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -9,9 +9,11 @@ import {
 
 export function registerMenu() {
   const menuIcon = `chrome://${config.addonRef}/content/icons/favicon.png`;
-  ztoolkit.Menu.register("item", {
-    tag: "menuseparator",
-  });
+  if (getPref("showItemMenuTitleTranslation") || getPref("showItemMenuAbstractTranslation")) {
+    ztoolkit.Menu.register("item", {
+      tag: "menuseparator",
+    });
+  }
   if (getPref("showItemMenuTitleTranslation")) {
     ztoolkit.Menu.register("item", {
       tag: "menuitem",

--- a/src/modules/services/youdaodict.ts
+++ b/src/modules/services/youdaodict.ts
@@ -27,30 +27,25 @@ export default <TranslateTaskProcessor>async function (data) {
     if (tgt.length != 0) {
       const audioList: Array<{ text: string; url: string }> = [];
 
-      const en = tgt.match(
-        /英 \[.+?\]/gm,
-      );
+      const en = tgt.match(/英 \[.+?\]/gm);
       if (en != null && en.length != 0) {
         audioList.push({
           text: en[0],
-          url: `https://dict.youdao.com/dictvoice?audio=${data.raw}&type=1`
-        })
+          url: `https://dict.youdao.com/dictvoice?audio=${data.raw}&type=1`,
+        });
       }
 
-      const us = tgt.match(
-        /美 \[.+?\]/gm,
-      );
+      const us = tgt.match(/美 \[.+?\]/gm);
       if (us != null && us.length != 0) {
         audioList.push({
           text: us[0],
-          url: `https://dict.youdao.com/dictvoice?audio=${data.raw}&type=2`
-        })
+          url: `https://dict.youdao.com/dictvoice?audio=${data.raw}&type=2`,
+        });
       }
       data.audio = audioList;
     }
 
     data.result = tgt;
-
   } catch (e) {
     throw "Parse Error";
   }


### PR DESCRIPTION
- Resolve: https://github.com/windingwind/zotero-better-notes/issues/1082#issuecomment-2306802546
- Do not add the menu separator line when both of the Item Menu checkboxes (ltem Menu: Show Title Translation, ltem Menu: Show Abstract Translation) are unchecked.