### PR TITLE
fix: show AddToNote in pupop even if unchecked (#1046)

### DIFF
--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -83,14 +83,13 @@ export function updateReaderPopup() {
   textarea.hidden = hidePopupTextarea || task.status === "waiting";
   textarea.value = task.result || task.raw;
   textarea.style.fontSize = `${getPref("fontSize")}px`;
-  textarea.style.lineHeight = `${
-    Number(getPref("lineHeight")) * Number(getPref("fontSize"))
-  }px`;
+  textarea.style.lineHeight = `${Number(getPref("lineHeight")) * Number(getPref("fontSize"))
+    }px`;
 
-  updateHidden(
-    addToNoteButton,
-    !Zotero.getMainWindow().ZoteroContextPane.activeEditor,
-  );
+  const enableAddToNote = getPref("enableNote") as boolean;
+  if (!Zotero.getMainWindow().ZoteroContextPane.activeEditor || !enableAddToNote) {
+    updateHidden(addToNoteButton, true);
+  }
 
   updatePopupSize(popup, textarea);
 }
@@ -179,9 +178,8 @@ export function buildReaderPopup(
           styles: {
             fontSize: `${getPref("fontSize")}px`,
             fontFamily: "inherit",
-            lineHeight: `${
-              Number(getPref("lineHeight")) * Number(getPref("fontSize"))
-            }px`,
+            lineHeight: `${Number(getPref("lineHeight")) * Number(getPref("fontSize"))
+              }px`,
             width: keepSize ? `${getPref("popupWidth")}px` : "-moz-available",
             // Minimum width to prevent the textarea from being smaller than the popup
             minWidth: "184px",

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -83,11 +83,15 @@ export function updateReaderPopup() {
   textarea.hidden = hidePopupTextarea || task.status === "waiting";
   textarea.value = task.result || task.raw;
   textarea.style.fontSize = `${getPref("fontSize")}px`;
-  textarea.style.lineHeight = `${Number(getPref("lineHeight")) * Number(getPref("fontSize"))
-    }px`;
+  textarea.style.lineHeight = `${
+    Number(getPref("lineHeight")) * Number(getPref("fontSize"))
+  }px`;
 
   const enableAddToNote = getPref("enableNote") as boolean;
-  if (!Zotero.getMainWindow().ZoteroContextPane.activeEditor || !enableAddToNote) {
+  if (
+    !Zotero.getMainWindow().ZoteroContextPane.activeEditor ||
+    !enableAddToNote
+  ) {
     updateHidden(addToNoteButton, true);
   }
 
@@ -178,8 +182,9 @@ export function buildReaderPopup(
           styles: {
             fontSize: `${getPref("fontSize")}px`,
             fontFamily: "inherit",
-            lineHeight: `${Number(getPref("lineHeight")) * Number(getPref("fontSize"))
-              }px`,
+            lineHeight: `${
+              Number(getPref("lineHeight")) * Number(getPref("fontSize"))
+            }px`,
             width: keepSize ? `${getPref("popupWidth")}px` : "-moz-available",
             // Minimum width to prevent the textarea from being smaller than the popup
             minWidth: "184px",


### PR DESCRIPTION
- Do not show the `Add To Note` button in the translation popup once `Show 'Add Translation to Note' in Popup` is unchecked.
    - Fixes: https://github.com/windingwind/zotero-pdf-translate/issues/1046