### PR TITLE
fix: abnormal link in preference panel

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -243,11 +243,14 @@
   <hbox align="center">
     <label
       data-l10n-id="pref-about-feedback"
+      is="zotero-text-link"
       class="zotero-text-link"
       href="https://github.com/windingwind/zotero-pdf-translate/issues"
+      style="margin-right: 4px"
     ></label>
     <label
       data-l10n-id="pref-about-docs"
+      is="zotero-text-link"
       class="zotero-text-link"
       href="https://zotero.yuque.com/staff-gkhviy/pdf-trans"
     ></label>


### PR DESCRIPTION
Fixes: The links in the About panel are unclickable.
And add a blank between the two links.