### PR TITLE
add: support aliyun professional edition service (#1124)

### DIFF
--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -117,6 +117,15 @@ service-cnki-dialog-close=Close
 service-cnki-dialog-title=CNKI Config
 service-cnki-dialog-split=Automatically split translation for more than 800 characters
 
+service-aliyun-secret-pass=Config
+service-aliyun-secret-fail=Config
+service-aliyun-dialog-title=Aliyun Config
+service-aliyun-dialog-action=Action
+service-aliyun-dialog-scene=Scene
+service-aliyun-dialog-help=Help
+service-aliyun-dialog-save=Save
+service-aliyun-dialog-close=Close
+
 readerpopup-translate-label=Translate
 
 pref-title=Translate

--- a/addon/locale/it-IT/addon.ftl
+++ b/addon/locale/it-IT/addon.ftl
@@ -105,6 +105,15 @@ service-cnki-dialog-close=Chiudi
 service-cnki-dialog-title=Configura CNKI
 service-cnki-dialog-split=Dividi automaticamente la traduzione per più di 800 caratteri
 
+service-aliyun-secret-pass=Configura
+service-aliyun-secret-fail=Configura
+service-aliyun-dialog-title=Configura Aliyun
+service-aliyun-dialog-action=Azione
+service-aliyun-dialog-scene=Scena
+service-aliyun-dialog-help=Aiuto
+service-aliyun-dialog-save=Salva
+service-aliyun-dialog-close=Chiudi
+
 readerpopup-translate-label=Traduci
 
 pref-title=Translate

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -116,6 +116,15 @@ service-cnki-dialog-close=关闭
 service-cnki-dialog-title=CNKI 设置
 service-cnki-dialog-split=超过800字符自动拆分翻译
 
+service-aliyun-secret-pass=配置
+service-aliyun-secret-fail=配置
+service-aliyun-dialog-title=Aliyun 配置
+service-aliyun-dialog-action=版本
+service-aliyun-dialog-scene=场景
+service-aliyun-dialog-help=帮助
+service-aliyun-dialog-save=保存
+service-aliyun-dialog-close=关闭
+
 readerpopup-translate-label=翻译
 
 pref-title=翻译

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -83,3 +83,5 @@ pref(
 );
 pref("__prefsPrefix__.qwenmt.model", "qwen-mt-plus");
 pref("__prefsPrefix__.qwenmt.domains", "");
+pref("__prefsPrefix__.aliyun.action", "TranslateGeneral");
+pref("__prefsPrefix__.aliyun.scene", "general");

--- a/src/modules/services/aliyun.ts
+++ b/src/modules/services/aliyun.ts
@@ -1,4 +1,5 @@
 import { base64, hmacSha1Digest, randomString } from "../../utils/crypto";
+import { getPref } from "../../utils/prefs";
 import { TranslateTaskProcessor } from "../../utils/task";
 
 export default <TranslateTaskProcessor>async function (data) {
@@ -6,6 +7,8 @@ export default <TranslateTaskProcessor>async function (data) {
   const accessKeyId = params[0];
   const accessKeySecret = params[1];
   const endpoint = params[2] || "https://mt.aliyuncs.com/";
+  const action = (getPref("aliyun.action") as string) || "TranslateGeneral";
+  const scene = (getPref("aliyun.scene") as string) || "general";
 
   function languageCode(str: string) {
     str = str.toLowerCase();
@@ -22,7 +25,7 @@ export default <TranslateTaskProcessor>async function (data) {
     );
   }
 
-  const encodedBody = `AccessKeyId=${accessKeyId}&Action=TranslateGeneral&Format=JSON&FormatType=text&SignatureMethod=HMAC-SHA1&SignatureNonce=${encodeURIComponent(
+  const encodedBody = `AccessKeyId=${accessKeyId}&Action=${action}&Format=JSON&FormatType=text&Scene=${scene}&SignatureMethod=HMAC-SHA1&SignatureNonce=${encodeURIComponent(
     randomString(12),
   )}&SignatureVersion=1.0&SourceLanguage=auto&SourceText=${encodeRFC3986URIComponent(
     data.raw,

--- a/src/modules/settings/aliyun.ts
+++ b/src/modules/settings/aliyun.ts
@@ -1,0 +1,99 @@
+import { getPref, setPref } from "../../utils/prefs";
+import { getString } from "../../utils/locale";
+
+export async function aliyunStatusCallback(status: boolean) {
+  const prefix = "aliyun";
+  const addonPrefix = prefix;
+
+  if (!status) {
+    return;
+  }
+
+  const dialog = new ztoolkit.Dialog(2, 1);
+  const dialogData: { [key: string | number]: any } = {
+    action: getPref(`${prefix}.action`),
+    scene: getPref(`${prefix}.scene`),
+  };
+
+  dialog
+    .setDialogData(dialogData)
+    .addCell(
+      0,
+      0,
+      {
+        tag: "div",
+        namespace: "html",
+        styles: {
+          display: "grid",
+          gridTemplateColumns: "1fr 4fr",
+          rowGap: "10px",
+          columnGap: "5px",
+        },
+        children: [
+          {
+            tag: "label",
+            namespace: "html",
+            attributes: {
+              for: "action",
+            },
+            properties: {
+              innerHTML: getString(`service-${addonPrefix}-dialog-action`),
+            },
+          },
+          {
+            tag: "input",
+            id: "action",
+            attributes: {
+              "data-bind": "action",
+              "data-prop": "value",
+              type: "string",
+            },
+          },
+          {
+            tag: "label",
+            namespace: "html",
+            attributes: {
+              for: "scene",
+            },
+            properties: {
+              innerHTML: getString(`service-${addonPrefix}-dialog-scene`),
+            },
+          },
+          {
+            tag: "input",
+            id: "scene",
+            attributes: {
+              "data-bind": "scene",
+              "data-prop": "value",
+              type: "string",
+            },
+          },
+        ],
+      },
+      false,
+    )
+    .addButton(getString(`service-${addonPrefix}-dialog-save`), "save")
+    .addButton(getString(`service-${addonPrefix}-dialog-close`), "close")
+    .addButton(getString(`service-${addonPrefix}-dialog-help`), "help");
+
+  dialog.open(getString(`service-${addonPrefix}-dialog-title`));
+
+  await dialogData.unloadLock?.promise;
+  switch (dialogData._lastButtonId) {
+    case "save":
+      {
+        setPref(`${prefix}.action`, dialogData.action);
+        setPref(`${prefix}.scene`, dialogData.scene);
+      }
+      break;
+    case "help":
+      {
+        Zotero.launchURL(
+          "https://help.aliyun.com/zh/machine-translation/developer-reference/api-overview-1",
+        );
+      }
+      break;
+    default:
+      break;
+  }
+}

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -4,6 +4,7 @@ import { geminiStatusCallback } from "./gemini";
 import { niutransStatusCallback } from "./niutrans";
 import { deeplxStatusCallback } from "./deeplx";
 import { qwenmtStatusCallback } from "./qwenmt";
+import { aliyunStatusCallback } from "./aliyun";
 
 export const secretStatusButtonData: {
   [key: string]: {
@@ -91,5 +92,12 @@ export const secretStatusButtonData: {
       fail: "service-qwenmt-secret-fail",
     },
     callback: qwenmtStatusCallback,
+  },
+  aliyun: {
+    labels: {
+      pass: "service-aliyun-secret-pass",
+      fail: "service-aliyun-secret-fail",
+    },
+    callback: aliyunStatusCallback,
   },
 };

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -71,6 +71,8 @@ declare namespace _ZoteroTypes {
       "qwenmt.endPoint": string;
       "qwenmt.model": string;
       "qwenmt.domains": string;
+      "aliyun.action": string;
+      "aliyun.scene": string;
     };
   }
 }


### PR DESCRIPTION
增加对阿里云的机器翻译专业版支持
添加了对话框来对普通版和专业版的参数选择
文档：https://help.aliyun.com/zh/machine-translation/developer-reference/api-overview-1

这里文档中对专业版和普通版使用`action`区分，英文我就采用action了，中文用的是`版本`，不知道这样行不行
![image](https://github.com/user-attachments/assets/8b2a029c-c23f-4f40-8856-76f262393769)
