### PR TITLE
feat: add setting for contactKey Ctrl, fixes #1134

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -166,16 +166,6 @@
     preference="__prefsPrefix__.showSidebarEngine"
   />
   <checkbox
-    data-l10n-id="pref-interface-showSidebarSettings"
-    native="true"
-    preference="__prefsPrefix__.showSidebarSettings"
-  />
-  <checkbox
-    data-l10n-id="pref-interface-showSidebarConcat"
-    native="true"
-    preference="__prefsPrefix__.showSidebarConcat"
-  />
-  <checkbox
     data-l10n-id="pref-interface-showSidebarLanguage"
     native="true"
     preference="__prefsPrefix__.showSidebarLanguage"
@@ -189,6 +179,21 @@
     data-l10n-id="pref-interface-rawResultOrder"
     native="true"
     preference="__prefsPrefix__.rawResultOrder"
+  />
+  <checkbox
+    data-l10n-id="pref-interface-showSidebarSettings"
+    native="true"
+    preference="__prefsPrefix__.showSidebarSettings"
+  />
+  <checkbox
+    data-l10n-id="pref-interface-showSidebarConcat"
+    native="true"
+    preference="__prefsPrefix__.showSidebarConcat"
+  />
+  <checkbox
+    data-l10n-id="pref-interface-enableConcatKey"
+    native="true"
+    preference="__prefsPrefix__.enableConcatKey"
   />
   <checkbox
     data-l10n-id="pref-interface-showSidebarCopy"

--- a/addon/locale/en-US/panel.ftl
+++ b/addon/locale/en-US/panel.ftl
@@ -16,10 +16,7 @@ autoTranslateAnnotation =
 
 selection = Selection:
 enableConcat =
-    .label = Concat Mode / { PLATFORM() ->
-        [macos] ⌘
-       *[other] Ctrl
-    }
+    .label = Concat Mode
 clearConcat =
     .label = Clear
 

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -60,9 +60,14 @@ pref-interface-showSidebarEngine =
 pref-interface-showSidebarLanguage =
     .label = Item Pane Section: Show Language Selection Menu
 pref-interface-showSidebarSettings =
-    .label = Item Pane Section: Show Settings
+    .label = Item Pane Section: Show Auto-Trans Settings
 pref-interface-showSidebarConcat =
     .label = Item Pane Section: Show Concatenated Translation Menu
+pref-interface-enableConcatKey =
+    .label = Item Pane Section: Hold down { PLATFORM() ->
+        [macos] ⌘
+       *[other] Ctrl
+    } to enable Concat Mode
 pref-interface-showSidebarRaw =
     .label = Item Pane Section: Show Raw
 pref-interface-showSidebarCopy =

--- a/addon/locale/it-IT/panel.ftl
+++ b/addon/locale/it-IT/panel.ftl
@@ -16,10 +16,7 @@ autoTranslateAnnotation =
 
 selection = Selection:
 enableConcat =
-    .label = Concat Mode / { PLATFORM() ->
-        [macos] ⌘
-       *[other] Ctrl
-    }
+    .label = Concat Mode
 clearConcat =
     .label = Clear
 

--- a/addon/locale/it-IT/preferences.ftl
+++ b/addon/locale/it-IT/preferences.ftl
@@ -60,9 +60,14 @@ pref-interface-showSidebarEngine =
 pref-interface-showSidebarLanguage =
     .label = Sezione del pannello dell'elemento: Mostra il menu di selezione della lingua
 pref-interface-showSidebarSettings =
-    .label = Sezione del pannello dell'elemento: Mostra le impostazioni
+    .label = Sezione del pannello dell'elemento: Mostra le Traduci automaticamente impostazioni
 pref-interface-showSidebarConcat =
     .label = Sezione del pannello dell'elemento: Mostra il menu per la traduzione concatenata
+pref-interface-enableConcatKey =
+    .label = Sezione del pannello dell'elemento: Tenere premuto il tasto { PLATFORM() ->
+        [macos] ⌘
+       *[other] Ctrl
+    } per attivare la modalità di giunzione
 pref-interface-showSidebarRaw =
     .label = Sezione del pannello dell'elemento: Mostra il testo originale
 pref-interface-showSidebarCopy =

--- a/addon/locale/zh-CN/panel.ftl
+++ b/addon/locale/zh-CN/panel.ftl
@@ -16,10 +16,7 @@ autoTranslateAnnotation =
 
 selection = 选区: 
 enableConcat =
-    .label = 拼接模式 / { PLATFORM() ->
-        [macos] ⌘
-       *[other] Ctrl
-    }
+    .label = 拼接模式
 clearConcat =
     .label = 清空
 

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -60,9 +60,14 @@ pref-interface-showSidebarEngine =
 pref-interface-showSidebarLanguage =
     .label = 条目面板区块：显示语言选择菜单
 pref-interface-showSidebarSettings =
-    .label = 条目面板区块：显示设置
+    .label = 条目面板区块：显示自动翻译设置
 pref-interface-showSidebarConcat =
     .label = 条目面板区块：显示拼接翻译菜单
+pref-interface-enableConcatKey =
+    .label = 条目面板区块：按住 { PLATFORM() ->
+        [macos] ⌘
+       *[other] Ctrl
+    } 键激活拼接模式
 pref-interface-showSidebarRaw =
     .label = 条目面板区块：显示原文
 pref-interface-showSidebarCopy =

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -19,6 +19,7 @@ pref("__prefsPrefix__.showItemMenuAbstractTranslation", true);
 pref("__prefsPrefix__.showSidebarEngine", true);
 pref("__prefsPrefix__.showSidebarSettings", true);
 pref("__prefsPrefix__.showSidebarConcat", true);
+pref("__prefsPrefix__.enableConcatKey", true);
 pref("__prefsPrefix__.showSidebarLanguage", true);
 pref("__prefsPrefix__.showSidebarRaw", true);
 pref("__prefsPrefix__.showSidebarCopy", true);

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -165,7 +165,8 @@ export function addTranslateTask(
   // Append raw text to last task's raw if in concat mode
   const isConcatMode =
     type === "text" &&
-    (addon.data.translate.concatCheckbox || addon.data.translate.concatKey);
+    (addon.data.translate.concatCheckbox ||
+      (getPref("enableConcatKey") && addon.data.translate.concatKey));
   const lastTask = getLastTranslateTask({ type: "text" });
   if (isConcatMode && lastTask) {
     lastTask.raw += " " + raw;

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -28,6 +28,7 @@ declare namespace _ZoteroTypes {
       "showSidebarEngine": boolean;
       "showSidebarSettings": boolean;
       "showSidebarConcat": boolean;
+      "enableConcatKey": boolean;
       "showSidebarLanguage": boolean;
       "showSidebarRaw": boolean;
       "showSidebarCopy": boolean;


### PR DESCRIPTION
- re: #1134 ，经测试，不勾选Auto-Trans: Selection时，选择同一页不连续的内容按下`Ctrl`+`T`翻译时，会自动激活拼接模式。
- 考虑可以增加Ctrl激活拼接模式的选项（因为Item Pane Section面板的空间有限，选择放在设置面板）
    1. 勾选Ctrl激活拼接模式且使用自动翻译Selection时，按住Ctrl选择内容即可拼接（和当前体验相同）
    2. 如果使用者习惯`Ctrl`+`T`翻译Selection内容，可以选择不勾选Ctrl激活拼接模式，如果需要拼接时，可以在Info面板选中Concat Mode使用拼接模式翻译

BTW，调整了设置面板的Item Pane Section设置项顺序，和翻译插件在Item Pane Section自上而下组件的顺序一致。