### PR TITLE
update locale string and fix broken hidden status for auto-play

### DIFF
--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -17,7 +17,7 @@ pref-basic-enableAnnotationFromSyncTranslation =
 pref-basic-enableNote =
     .label = Show "Add Translation to Note" in Pop-up
 pref-basic-enableNoteReplaceMode =
-    .label = Replace Raw Text When Adding to Note
+    .label = Replace Raw Text When Adding Translation to Note
 
 pref-audio-autoPlay =
     .label = Auto-play Pronunciation

--- a/addon/locale/it-IT/preferences.ftl
+++ b/addon/locale/it-IT/preferences.ftl
@@ -17,7 +17,7 @@ pref-basic-enableAnnotationFromSyncTranslation =
 pref-basic-enableNote =
     .label = Mostra "Aggiungi traduzione alla nota" nel popup
 pref-basic-enableNoteReplaceMode =
-    .label = Sostituisci il testo d'origine quando aggiungi alla nota
+    .label = Sostituisci il testo d'origine quando aggiungi traduzione alla nota
 
 pref-audio-autoPlay =
     .label = Riproduci automaticamente la pronuncia

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -17,7 +17,7 @@ pref-basic-enableAnnotationFromSyncTranslation =
 pref-basic-enableNote =
     .label = 在弹窗中显示“添加翻译至笔记”
 pref-basic-enableNoteReplaceMode =
-    .label = 添加到笔记时替换原始文本
+    .label = 添加翻译至笔记时替换原始文本
 
 pref-audio-autoPlay =
     .label = 自动播放发音

--- a/src/modules/preferenceWindow.ts
+++ b/src/modules/preferenceWindow.ts
@@ -300,6 +300,9 @@ function onPrefsEvents(type: string, fromElement: boolean = true) {
           : (getPref("enableDict") as boolean);
         const hidden = !elemValue;
         setDisabled("use-word-service", hidden);
+        if (!hidden) {
+          onPrefsEvents("setShowPlayBtn", fromElement);
+        }
       }
       break;
     case "setSentenceService":


### PR DESCRIPTION
- 将添加到笔记时替换原始文本修改为添加翻译至笔记时替换原始文本，和Pop-up的button内容一致, after [c8ef807](https://github.com/windingwind/zotero-pdf-translate/commit/c8ef807080d6ad00a158bbceb58eeadf72b1e57c)
- 修复在Use Word service保持勾选时，auto-play仅在取消勾选Show Play Buttons in Pop-up Panel后短暂hidden，再次打开设置面板仍然可见, re #1149