### PR TITLE
feat: add default values for Claude

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -88,7 +88,10 @@ pref("__prefsPrefix__.aliyun.action", "TranslateGeneral");
 pref("__prefsPrefix__.aliyun.scene", "general");
 
 pref("__prefsPrefix__.claude.stream", true);
-pref("__prefsPrefix__.claude.endPoint", "https://api.anthropic.com/v1/messages");
+pref(
+  "__prefsPrefix__.claude.endPoint",
+  "https://api.anthropic.com/v1/messages",
+);
 pref("__prefsPrefix__.claude.model", "claude-3-7-sonnet-20250219");
 pref("__prefsPrefix__.claude.temperature", "0.3");
 pref(
@@ -96,4 +99,3 @@ pref(
   "As an academic expert with specialized knowledge in various fields, please provide a proficient and precise translation from ${langFrom} to ${langTo} of the academic text enclosed in 🔤. It is crucial to maintaining the original phrase or sentence and ensure accuracy while utilizing the appropriate language. The text is as follows:  🔤 ${sourceText} 🔤  Please provide the translated result without any additional explanation and remove 🔤.",
 );
 pref("__prefsPrefix__.claude.maxTokens", "4000");
-

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -86,3 +86,14 @@ pref("__prefsPrefix__.qwenmt.model", "qwen-mt-plus");
 pref("__prefsPrefix__.qwenmt.domains", "");
 pref("__prefsPrefix__.aliyun.action", "TranslateGeneral");
 pref("__prefsPrefix__.aliyun.scene", "general");
+
+pref("__prefsPrefix__.claude.stream", true);
+pref("__prefsPrefix__.claude.endPoint", "https://api.anthropic.com/v1/messages");
+pref("__prefsPrefix__.claude.model", "claude-3-7-sonnet-20250219");
+pref("__prefsPrefix__.claude.temperature", "0.3");
+pref(
+  "__prefsPrefix__.claude.prompt",
+  "As an academic expert with specialized knowledge in various fields, please provide a proficient and precise translation from ${langFrom} to ${langTo} of the academic text enclosed in 🔤. It is crucial to maintaining the original phrase or sentence and ensure accuracy while utilizing the appropriate language. The text is as follows:  🔤 ${sourceText} 🔤  Please provide the translated result without any additional explanation and remove 🔤.",
+);
+pref("__prefsPrefix__.claude.maxTokens", "4000");
+

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -74,6 +74,12 @@ declare namespace _ZoteroTypes {
       "qwenmt.domains": string;
       "aliyun.action": string;
       "aliyun.scene": string;
+      "claude.stream": boolean;
+      "claude.endPoint": string;
+      "claude.model": string;
+      "claude.temperature": string;
+      "claude.prompt": string;
+      "claude.maxTokens": string;
     };
   }
 }


### PR DESCRIPTION
This pull request adds new preferences for configuring the Claude translation model in the `addon/prefs.js` file. These changes introduce settings for the model's endpoint, parameters, and prompt structure.

### New preferences for Claude translation model:

* Added a new preference for enabling streaming responses with the key `__prefsPrefix__.claude.stream`.
* Defined the endpoint for the Claude API using the key `__prefsPrefix__.claude.endPoint`.
* Configured the model version to `claude-3-7-sonnet-20250219` with the key `__prefsPrefix__.claude.model`.
* Introduced a preference for temperature control (`__prefsPrefix__.claude.temperature`) and set it to `0.3` for deterministic results.
* Added a detailed prompt structure for academic translation tasks under the key `__prefsPrefix__.claude.prompt`. This ensures precise translations while maintaining the original meaning.
* Set a maximum token limit for responses with the key `__prefsPrefix__.claude.maxTokens`, capped at `4000`.