### PR TITLE
feat: remove newline from llm response

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -230,6 +230,13 @@
     <label><html:h2 data-l10n-id="pref-advanced"></html:h2></label>
     <hbox align="center">
       <checkbox
+        data-l10n-id="pref-advanced-stripEmptyLines"
+        native="true"
+        preference="__prefsPrefix__.stripEmptyLines"
+      />
+    </hbox>
+    <hbox align="center">
+      <checkbox
         data-l10n-id="pref-advanced-enableAutoDetectLanguage"
         native="true"
         preference="__prefsPrefix__.enableAutoDetectLanguage"

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -103,3 +103,6 @@ pref-about-docs =
     .value = Documentation (ZH)
 pref-about-version =
     .value = { $name } Version { $version } Build { $time }
+
+pref-advanced-stripEmptyLines =
+    .label = Strip empty lines from translation results

--- a/addon/locale/it-IT/preferences.ftl
+++ b/addon/locale/it-IT/preferences.ftl
@@ -103,3 +103,6 @@ pref-about-docs =
     .value = Documentazione (ZH)
 pref-about-version =
     .value = { $name } Versione { $version } Build { $time }
+
+pref-advanced-stripEmptyLines =
+    .label = Rimuovi le righe vuote dai risultati della traduzione

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -103,3 +103,6 @@ pref-about-docs =
     .value = 文档 (中文)
 pref-about-version =
     .value = { $name } 版本 { $version } Build { $time }
+
+pref-advanced-stripEmptyLines =
+    .label = 从翻译结果中删除空行

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -86,3 +86,5 @@ pref("__prefsPrefix__.qwenmt.model", "qwen-mt-plus");
 pref("__prefsPrefix__.qwenmt.domains", "");
 pref("__prefsPrefix__.aliyun.action", "TranslateGeneral");
 pref("__prefsPrefix__.aliyun.scene", "general");
+
+pref("__prefsPrefix__.stripEmptyLines", false);

--- a/src/modules/services/index.ts
+++ b/src/modules/services/index.ts
@@ -244,8 +244,9 @@ export class TranslationServices {
                   ? item.annotationComment
                   : item.annotationText) || ""
               ).replace(regex, "");
-              let text = `${currentText[currentText.length - 1] === "\n" ? "" : "\n"
-                }${splitChar}${task.result}${splitChar}\n`;
+              let text = `${
+                currentText[currentText.length - 1] === "\n" ? "" : "\n"
+              }${splitChar}${task.result}${splitChar}\n`;
               text = splitChar === "" ? text : `${currentText}${text}`;
               item[
                 savePosition === "comment"

--- a/src/modules/services/index.ts
+++ b/src/modules/services/index.ts
@@ -5,6 +5,8 @@ import {
   TranslateTaskRunner,
 } from "../../utils/task";
 
+import { stripEmptyLines } from "../../utils/str";
+
 export class TranslationServices {
   [key: string]: TranslateTaskRunner | unknown;
   constructor() {
@@ -193,6 +195,13 @@ export class TranslationServices {
       }
       // Run task
       await runner.run(task);
+
+      // Apply strip empty lines if enabled
+      const stripEnabled = getPref("stripEmptyLines") as boolean;
+      if (stripEnabled && task.result) {
+        task.result = stripEmptyLines(task.result, true);
+      }
+
       // Run extra tasks. Do not wait.
       if (task.extraTasks?.length) {
         Promise.all(
@@ -235,9 +244,8 @@ export class TranslationServices {
                   ? item.annotationComment
                   : item.annotationText) || ""
               ).replace(regex, "");
-              let text = `${
-                currentText[currentText.length - 1] === "\n" ? "" : "\n"
-              }${splitChar}${task.result}${splitChar}\n`;
+              let text = `${currentText[currentText.length - 1] === "\n" ? "" : "\n"
+                }${splitChar}${task.result}${splitChar}\n`;
               text = splitChar === "" ? text : `${currentText}${text}`;
               item[
                 savePosition === "comment"

--- a/src/utils/str.ts
+++ b/src/utils/str.ts
@@ -18,3 +18,19 @@ export function fill(
     options.char,
   );
 }
+
+/**
+ * Strip empty lines from text
+ * @param text Text to process
+ * @param enabled Whether stripping is enabled
+ * @returns Processed text
+ */
+export function stripEmptyLines(text: string, enabled: boolean): string {
+  if (!text || !enabled) return text;
+
+  // Normalize line endings to \n
+  const normalizedText = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  // Replace multiple consecutive line breaks with a single one
+  return normalizedText.replace(/\n{2,}/g, '\n');
+}

--- a/src/utils/str.ts
+++ b/src/utils/str.ts
@@ -29,8 +29,8 @@ export function stripEmptyLines(text: string, enabled: boolean): string {
   if (!text || !enabled) return text;
 
   // Normalize line endings to \n
-  const normalizedText = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const normalizedText = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 
   // Replace multiple consecutive line breaks with a single one
-  return normalizedText.replace(/\n{2,}/g, '\n');
+  return normalizedText.replace(/\n{2,}/g, "\n");
 }

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -74,6 +74,7 @@ declare namespace _ZoteroTypes {
       "qwenmt.domains": string;
       "aliyun.action": string;
       "aliyun.scene": string;
+      "stripEmptyLines": boolean;
     };
   }
 }


### PR DESCRIPTION
This pull request introduces a new feature to strip empty lines from translation results, along with necessary UI, localization, and backend changes to support it. The feature can be toggled via a new preference in the application settings.

### Feature Implementation: Strip Empty Lines

#### UI and Localization Updates:
* Added a new checkbox in the advanced preferences section to enable or disable the "Strip Empty Lines" feature (`addon/chrome/content/preferences.xhtml`).
* Updated localization files to include the label for the new preference in English, Italian, and Chinese (`addon/locale/en-US/preferences.ftl`, `addon/locale/it-IT/preferences.ftl`, `addon/locale/zh-CN/preferences.ftl`). [[1]](diffhunk://#diff-8b21f73c3b3b782dff21e947b73d8dd2dde9553b53d7d7efbebd451dddc368afR106-R108) [[2]](diffhunk://#diff-6fbb7c2fb066da545149dd57e4606da07d34429935d916c244c7e26b6b626318R106-R108) [[3]](diffhunk://#diff-d04c18892ed72223035966c81d45fafcad02d90913fa5e57f6591fe1c213f06fR106-R108)

#### Backend Logic:
* Added a new preference `__prefsPrefix__.stripEmptyLines` with a default value of `false` in `addon/prefs.js`.
* Implemented the `stripEmptyLines` utility function to normalize line endings and remove consecutive empty lines in `src/utils/str.ts`.
* Integrated the `stripEmptyLines` function into the translation service logic, applying it to translation results if the preference is enabled (`src/modules/services/index.ts`). [[1]](diffhunk://#diff-b0d0663c4179f0ea422d7088a93b8293f6f122ba6a0cda5d29d0147ee8ad6f7aR8-R9) [[2]](diffhunk://#diff-b0d0663c4179f0ea422d7088a93b8293f6f122ba6a0cda5d29d0147ee8ad6f7aR198-R204)

These changes ensure that users have the option to clean up translation outputs by removing unnecessary empty lines, improving readability and usability.