### PR TITLE
fix: #1146 zotero-beta-login-failure

### DIFF
--- a/src/modules/settings/niutrans.ts
+++ b/src/modules/settings/niutrans.ts
@@ -353,7 +353,11 @@ async function niutransLogin(username: string, password: string) {
   encryptionPassword = encodeURIComponent(encryptionPassword);
 
   // Login with the encrypted password and session ID
-  const userLoginResponse = await loginApi(username, encryptionPassword, jsessionid);
+  const userLoginResponse = await loginApi(
+    username,
+    encryptionPassword,
+    jsessionid,
+  );
 
   if (userLoginResponse?.status === 200) {
     if (userLoginResponse.response.flag === 1) {
@@ -374,7 +378,11 @@ async function niutransLogin(username: string, password: string) {
   return { loginFlag, loginErrorMessage };
 }
 
-async function loginApi(username: string, password: string, jsessionid: string) {
+async function loginApi(
+  username: string,
+  password: string,
+  jsessionid: string,
+) {
   return await Zotero.HTTP.request(
     "POST",
     "https://apis.niutrans.com/NiuTransAPIServer/checkInformation",
@@ -382,8 +390,8 @@ async function loginApi(username: string, password: string, jsessionid: string) 
       body: `account=${username}&encryptionPassword=${password}`,
       responseType: "json",
       headers: {
-        "Cookie": `JSESSIONID=${jsessionid}`
-      }
+        Cookie: `JSESSIONID=${jsessionid}`,
+      },
     },
   );
 }
@@ -396,8 +404,8 @@ async function setDictLibList(apikey: string, jsessionid: string) {
       body: `apikey=${apikey}`,
       responseType: "json",
       headers: {
-        "Cookie": `JSESSIONID=${jsessionid}`
-      }
+        Cookie: `JSESSIONID=${jsessionid}`,
+      },
     },
   );
   if (xhr?.status === 200 && xhr.response.flag !== 0) {
@@ -430,8 +438,8 @@ async function setMemoryLibList(apikey: string, jsessionid: string) {
       body: `apikey=${apikey}`,
       responseType: "json",
       headers: {
-        "Cookie": `JSESSIONID=${jsessionid}`
-      }
+        Cookie: `JSESSIONID=${jsessionid}`,
+      },
     },
   );
 
@@ -463,7 +471,7 @@ async function getPublicKey() {
     "GET",
     "https://apis.niutrans.com/NiuTransAPIServer/getpublickey",
     {
-      responseType: "json"
+      responseType: "json",
     },
   );
 }

--- a/src/modules/settings/niutrans.ts
+++ b/src/modules/settings/niutrans.ts
@@ -325,50 +325,79 @@ export async function niutransStatusCallback(status: boolean) {
 async function niutransLogin(username: string, password: string) {
   let loginFlag = false;
   let loginErrorMessage = "Not login";
-  const keyxhr = await getPublicKey();
-  if (keyxhr?.status !== 200 || keyxhr.response.flag !== 1) {
+
+  // Get the public key with a proper HTTPS request
+  const keyResponse = await getPublicKey();
+
+  // Verify the response was successful and has the expected flag
+  if (keyResponse?.status !== 200 || keyResponse.response.flag !== 1) {
     return { loginFlag, loginErrorMessage };
   }
+
+  // Get the JSESSIONID from the response headers
+  let jsessionid = "";
+
+  // Extract JSESSIONID from the response header
+  const setCookie = keyResponse.getResponseHeader?.("Set-Cookie") || "";
+  if (setCookie && setCookie.includes("JSESSIONID=")) {
+    const match = setCookie.match(/JSESSIONID=([^;]+)/);
+    if (match && match[1]) {
+      jsessionid = match[1];
+    }
+  }
+
+  // Encrypt the password using the public key
   const encrypt = new JSEncrypt();
-  encrypt.setPublicKey(keyxhr.response.key);
+  encrypt.setPublicKey(keyResponse.response.key);
   let encryptionPassword = encrypt.encrypt(password);
   encryptionPassword = encodeURIComponent(encryptionPassword);
-  const userLoginXhr = await loginApi(username, encryptionPassword);
-  if (userLoginXhr?.status === 200) {
-    if (userLoginXhr.response.flag === 1) {
-      const apikey = userLoginXhr.response.apikey;
+
+  // Login with the encrypted password and session ID
+  const userLoginResponse = await loginApi(username, encryptionPassword, jsessionid);
+
+  if (userLoginResponse?.status === 200) {
+    if (userLoginResponse.response.flag === 1) {
+      const apikey = userLoginResponse.response.apikey;
       setPref("niutransUsername", username);
       setPref("niutransPassword", password);
       setServiceSecret("niutranspro", apikey);
-      await setDictLibList(apikey);
-      await setMemoryLibList(apikey);
+
+      // Use the same JSESSIONID for subsequent requests
+      await setDictLibList(apikey, jsessionid);
+      await setMemoryLibList(apikey, jsessionid);
       loginFlag = true;
     } else {
       loginFlag = false;
-      loginErrorMessage = userLoginXhr.response.msg;
+      loginErrorMessage = userLoginResponse.response.msg;
     }
   }
   return { loginFlag, loginErrorMessage };
 }
 
-async function loginApi(username: string, password: string) {
+async function loginApi(username: string, password: string, jsessionid: string) {
   return await Zotero.HTTP.request(
     "POST",
     "https://apis.niutrans.com/NiuTransAPIServer/checkInformation",
     {
       body: `account=${username}&encryptionPassword=${password}`,
       responseType: "json",
+      headers: {
+        "Cookie": `JSESSIONID=${jsessionid}`
+      }
     },
   );
 }
 
-async function setDictLibList(apikey: string) {
+async function setDictLibList(apikey: string, jsessionid: string) {
   const xhr = await Zotero.HTTP.request(
     "POST",
     "https://apis.niutrans.com/NiuTransAPIServer/getDictLibList",
     {
       body: `apikey=${apikey}`,
       responseType: "json",
+      headers: {
+        "Cookie": `JSESSIONID=${jsessionid}`
+      }
     },
   );
   if (xhr?.status === 200 && xhr.response.flag !== 0) {
@@ -393,13 +422,16 @@ async function setDictLibList(apikey: string) {
   }
 }
 
-async function setMemoryLibList(apikey: string) {
+async function setMemoryLibList(apikey: string, jsessionid: string) {
   const xhr = await Zotero.HTTP.request(
     "POST",
     "https://apis.niutrans.com/NiuTransAPIServer/getMemoryLibList",
     {
       body: `apikey=${apikey}`,
       responseType: "json",
+      headers: {
+        "Cookie": `JSESSIONID=${jsessionid}`
+      }
     },
   );
 
@@ -431,7 +463,7 @@ async function getPublicKey() {
     "GET",
     "https://apis.niutrans.com/NiuTransAPIServer/getpublickey",
     {
-      responseType: "json",
+      responseType: "json"
     },
   );
 }


### PR DESCRIPTION
This pull request enhances the functionality and security of the `niutransLogin` process by introducing session management via `JSESSIONID` and improving the handling of API requests. The changes primarily focus on adding session-based authentication and ensuring proper use of headers for subsequent API calls.

### Improvements to session management:

* Extracted `JSESSIONID` from the response headers of the `getPublicKey` request and included it in subsequent API calls for session-based authentication. (`src/modules/settings/niutrans.ts`, [src/modules/settings/niutrans.tsL328-R400](diffhunk://#diff-e09db0599ce03a1dfe6258e5aa9eddb712a9309087d4734c59f5e2689df8dfb5L328-R400))

### Updates to API request handling:

* Modified `loginApi`, `setDictLibList`, and `setMemoryLibList` functions to include the `JSESSIONID` in the `Cookie` header for better session handling. (`src/modules/settings/niutrans.ts`, [[1]](diffhunk://#diff-e09db0599ce03a1dfe6258e5aa9eddb712a9309087d4734c59f5e2689df8dfb5L328-R400) [[2]](diffhunk://#diff-e09db0599ce03a1dfe6258e5aa9eddb712a9309087d4734c59f5e2689df8dfb5L396-R434)
* Ensured consistent use of the `JSESSIONID` across all related API calls to maintain session integrity. (`src/modules/settings/niutrans.ts`, [[1]](diffhunk://#diff-e09db0599ce03a1dfe6258e5aa9eddb712a9309087d4734c59f5e2689df8dfb5L328-R400) [[2]](diffhunk://#diff-e09db0599ce03a1dfe6258e5aa9eddb712a9309087d4734c59f5e2689df8dfb5L396-R434)

### Minor code cleanup:

* Removed unnecessary trailing commas in the `getPublicKey` function's request options for improved readability. (`src/modules/settings/niutrans.ts`, [src/modules/settings/niutrans.tsL434-R466](diffhunk://#diff-e09db0599ce03a1dfe6258e5aa9eddb712a9309087d4734c59f5e2689df8dfb5L434-R466))