### PR TITLE
feat: add LibreTranslate service integration and configuration options (#944)

### DIFF
--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -155,3 +155,14 @@ field-titleTranslation=Title Translation
 field-abstractTranslation=Abstract Translation
 
 status-translating=Translating...
+
+
+service-libretranslate=LibreTranslate
+service-libretranslate-secret-pass=Config
+service-libretranslate-secret-fail=Config
+service-libretranslate-dialog-title=LibreTranslate Config
+service-libretranslate-dialog-endPoint=API Endpoint
+service-libretranslate-dialog-save=Save
+service-libretranslate-dialog-close=Close
+service-libretranslate-dialog-help=Help
+

--- a/addon/locale/en-US/panel.ftl
+++ b/addon/locale/en-US/panel.ftl
@@ -100,3 +100,6 @@ service-freedictionaryapi =
     .label = FreeDictionaryAPI(en↔en)
 service-webliodict =
     .label = weblio(en↔ja)
+
+service-libretranslate =
+    .label = LibreTranslate

--- a/addon/locale/it-IT/addon.ftl
+++ b/addon/locale/it-IT/addon.ftl
@@ -129,3 +129,12 @@ field-titleTranslation=Traduzione del titolo
 field-abstractTranslation=Traduzione dell'Abstract
 
 status-translating=Traduzione in corso...
+
+service-libretranslate=LibreTranslate
+service-libretranslate-secret-pass=Configura
+service-libretranslate-secret-fail=Configura
+service-libretranslate-dialog-title=Configura LibreTranslate
+service-libretranslate-dialog-endPoint=API Endpoint
+service-libretranslate-dialog-save=Salva
+service-libretranslate-dialog-close=Chiudi
+service-libretranslate-dialog-help=Aiuto

--- a/addon/locale/it-IT/panel.ftl
+++ b/addon/locale/it-IT/panel.ftl
@@ -100,3 +100,6 @@ service-freedictionaryapi =
     .label = FreeDictionaryAPI(en↔en)
 service-webliodict =
     .label = weblio(en↔ja)
+
+service-libretranslate =
+    .label = LibreTranslate

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -154,3 +154,12 @@ field-titleTranslation=标题翻译
 field-abstractTranslation=摘要翻译
 
 status-translating=正在翻译...
+
+service-libretranslate=LibreTranslate
+service-libretranslate-secret-pass=配置
+service-libretranslate-secret-fail=配置
+service-libretranslate-dialog-title=LibreTranslate 配置
+service-libretranslate-dialog-endPoint=API 地址
+service-libretranslate-dialog-save=保存
+service-libretranslate-dialog-close=关闭
+service-libretranslate-dialog-help=帮助

--- a/addon/locale/zh-CN/panel.ftl
+++ b/addon/locale/zh-CN/panel.ftl
@@ -100,3 +100,6 @@ service-freedictionaryapi =
     .label = FreeDictionaryAPI(en↔en)
 service-webliodict =
     .label = weblio(en↔ja)
+
+service-libretranslate =
+    .label = LibreTranslate

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -86,3 +86,5 @@ pref("__prefsPrefix__.qwenmt.model", "qwen-mt-plus");
 pref("__prefsPrefix__.qwenmt.domains", "");
 pref("__prefsPrefix__.aliyun.action", "TranslateGeneral");
 pref("__prefsPrefix__.aliyun.scene", "general");
+
+pref("__prefsPrefix__.libretranslate.endpoint", "http://localhost:5000");

--- a/src/modules/services/index.ts
+++ b/src/modules/services/index.ts
@@ -8,6 +8,9 @@ import {
 export class TranslationServices {
   [key: string]: TranslateTaskRunner | unknown;
   constructor() {
+    import("./libretranslate").then(
+      (e) => (this.libretranslate = new TranslateTaskRunner(e.default)),
+    );
     import("./huoshan").then(
       (e) => (this.huoshan = new TranslateTaskRunner(e.default)),
     );

--- a/src/modules/services/libretranslate.ts
+++ b/src/modules/services/libretranslate.ts
@@ -1,0 +1,39 @@
+import { TranslateTaskProcessor } from "../../utils/task";
+import { getPref } from "../../utils/prefs";
+
+export default <TranslateTaskProcessor>async function (data) {
+  const endpoint =
+    (getPref("libretranslate.endpoint") as string) || "http://localhost:5000";
+  const apiKey = data.secret; // Use the secret as the API key
+
+  // Prepare request body
+  const requestBody: any = {
+    q: data.raw,
+    source: data.langfrom.split("-")[0],
+    target: data.langto.split("-")[0],
+    format: "text",
+  };
+
+  // Only add API key if it exists
+  if (apiKey) {
+    requestBody.api_key = apiKey;
+  }
+
+  const xhr = await Zotero.HTTP.request("POST", `${endpoint}/translate`, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(requestBody),
+    responseType: "json",
+  });
+
+  if (xhr?.status !== 200) {
+    throw `Request error: ${xhr?.status}`;
+  }
+
+  if (xhr.response.error) {
+    throw `Service error: ${xhr.response.error}`;
+  }
+
+  data.result = xhr.response.translatedText;
+};

--- a/src/modules/settings/index.ts
+++ b/src/modules/settings/index.ts
@@ -6,6 +6,7 @@ import { deeplxStatusCallback } from "./deeplx";
 import { qwenmtStatusCallback } from "./qwenmt";
 import { claudeStatusCallback } from "./claude";
 import { aliyunStatusCallback } from "./aliyun";
+import { libretranslateStatusCallback } from "./libretranslate";
 
 export const secretStatusButtonData: {
   [key: string]: {
@@ -13,6 +14,13 @@ export const secretStatusButtonData: {
     callback(status: boolean): void;
   };
 } = {
+  libretranslate: {
+    labels: {
+      pass: "service-libretranslate-secret-pass",
+      fail: "service-libretranslate-secret-fail",
+    },
+    callback: libretranslateStatusCallback,
+  },
   niutranspro: {
     labels: {
       pass: "service-niutranspro-secret-pass",

--- a/src/modules/settings/libretranslate.ts
+++ b/src/modules/settings/libretranslate.ts
@@ -1,0 +1,69 @@
+import { getPref, setPref } from "../../utils/prefs";
+import { getString } from "../../utils/locale";
+
+export async function libretranslateStatusCallback(status: boolean) {
+  const dialog = new ztoolkit.Dialog(2, 1);
+  const dialogData: { [key: string | number]: any } = {
+    endpoint: getPref("libretranslate.endpoint") || "http://localhost:5000",
+  };
+
+  dialog
+    .setDialogData(dialogData)
+    .addCell(
+      0,
+      0,
+      {
+        tag: "div",
+        namespace: "html",
+        styles: {
+          display: "grid",
+          gridTemplateColumns: "1fr 4fr",
+          rowGap: "10px",
+          columnGap: "5px",
+        },
+        children: [
+          {
+            tag: "label",
+            namespace: "html",
+            attributes: {
+              for: "endpoint",
+            },
+            properties: {
+              innerHTML: getString("service-libretranslate-dialog-endPoint"),
+            },
+          },
+          {
+            tag: "input",
+            id: "endpoint",
+            attributes: {
+              "data-bind": "endpoint",
+              "data-prop": "value",
+              type: "string",
+            },
+          },
+        ],
+      },
+      false,
+    )
+    .addButton(getString("service-libretranslate-dialog-save"), "save")
+    .addButton(getString("service-libretranslate-dialog-close"), "close")
+    .addButton(getString("service-libretranslate-dialog-help"), "help");
+
+  dialog.open(getString("service-libretranslate-dialog-title"));
+
+  await dialogData.unloadLock?.promise;
+  switch (dialogData._lastButtonId) {
+    case "save":
+      {
+        setPref("libretranslate.endpoint", dialogData.endpoint);
+      }
+      break;
+    case "help":
+      {
+        Zotero.launchURL("https://github.com/LibreTranslate/LibreTranslate");
+      }
+      break;
+    default:
+      break;
+  }
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -18,6 +18,19 @@ export interface SecretValidateResult {
 export const SERVICES: Readonly<Readonly<TranslateService>[]> = <const>[
   {
     type: "sentence",
+    id: "libretranslate",
+    defaultSecret: "",
+    secretValidator(secret: string) {
+      // API key is optional in LibreTranslate
+      return {
+        secret,
+        status: true,
+        info: "",
+      };
+    },
+  },
+  {
+    type: "sentence",
     id: "googleapi",
   },
   {

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -74,6 +74,7 @@ declare namespace _ZoteroTypes {
       "qwenmt.domains": string;
       "aliyun.action": string;
       "aliyun.scene": string;
+      "libretranslate.endpoint": string;
     };
   }
 }


### PR DESCRIPTION
lint is applied. 

This pull request introduces support for the LibreTranslate translation service, including its integration into the system, configuration options, and localization. Below are the key changes grouped by theme:

### Localization Updates:
* Added LibreTranslate-related strings in `addon/locale/en-US/addon.ftl`, `addon/locale/it-IT/addon.ftl`, and `addon/locale/zh-CN/addon.ftl` to support English, Italian, and Simplified Chinese. These include labels for configuration dialogs and API endpoints. [[1]](diffhunk://#diff-a423c4e18e0c11b4618780c0215b01af0cda2624de66ab598cd2f89774401e1bR158-R168) [[2]](diffhunk://#diff-f7f0504861a799b96445ddd1f2390a9683cc5aba9846c283af8a62471004bcacR132-R140) [[3]](diffhunk://#diff-56144515f3378bd259fd4ff20ab6457a00750b2d557f8f8bc84bb816605be0e2R157-R165)
* Updated `panel.ftl` files in the respective locales to include a label for LibreTranslate in the service list. [[1]](diffhunk://#diff-2009917bff9dd8ee02f37d02647a0e333898ce321db7997b9841ddbc5d8b8190R103-R105) [[2]](diffhunk://#diff-3a64bf7fcd3a985f6e437858db4770df46994aa72703f8f8bc5d9705a8cdceddR103-R105)

### Backend Integration:
* Added a new `libretranslate` module (`src/modules/services/libretranslate.ts`) to handle translation requests using LibreTranslate's API. It includes API endpoint configuration and request handling logic.
* Registered the LibreTranslate service in `src/modules/services/index.ts` to dynamically load the module and initialize it as a `TranslateTaskRunner`.

### Configuration and Settings:
* Introduced a new preference `libretranslate.endpoint` in `addon/prefs.js` to store the LibreTranslate API endpoint, defaulting to `http://localhost:5000`.
* Added a LibreTranslate-specific configuration dialog in `src/modules/settings/libretranslate.ts`, allowing users to set the API endpoint and access help documentation.
* Updated `src/modules/settings/index.ts` to include LibreTranslate's status callback for validating and managing its configuration.

### Service Registration:
* Registered LibreTranslate in the `SERVICES` array in `src/utils/config.ts` with a `secretValidator` function that validates API keys (optional for LibreTranslate).