### PR TITLE
修复通过自定义GPT调用openrouter的gemini api开启stream时回复内容不完全问题

### DIFF
--- a/src/modules/services/gpt.ts
+++ b/src/modules/services/gpt.ts
@@ -47,10 +47,10 @@ const gptTranslate = async function (
         try {
           const obj = JSON.parse(data);
           const choice = obj.choices[0];
+          result += choice.delta.content || "";
           if (choice.finish_reason) {
             break;
           }
-          result += choice.delta.content || "";
         } catch {
           continue;
         }


### PR DESCRIPTION
使用自定义GPT开启stream调用openrouter的gemini api时回复的内容总是不全，与 #1032 的描述一致，将 https://github.com/windingwind/zotero-pdf-translate/blob/051e25f6b239be7cbf2bc9552b321a22adebbe6c/src/modules/services/gpt.ts#L53
调至`if`前，stream下最后一个回复的`finish_reason`是`stop`，会content丢失。