### PR TITLE
chore: make prompt area adjustable

### DIFF
--- a/src/modules/settings/claude.ts
+++ b/src/modules/settings/claude.ts
@@ -120,7 +120,7 @@ export async function claudeStatusCallback(status: boolean) {
             },
           },
           {
-            tag: "input",
+            tag: "textarea",
             id: "prompt",
             attributes: {
               "data-bind": "prompt",

--- a/src/modules/settings/gpt.ts
+++ b/src/modules/settings/gpt.ts
@@ -29,6 +29,8 @@ async function gptStatusCallback(
           gridTemplateColumns: "1fr 4fr",
           rowGap: "10px",
           columnGap: "5px",
+          minWidth: "400px",
+          minHeight: "200px",
         },
         children: [
           {
@@ -131,7 +133,7 @@ async function gptStatusCallback(
             },
           },
           {
-            tag: "input",
+            tag: "textarea",
             id: "prompt",
             attributes: {
               "data-bind": "prompt",


### PR DESCRIPTION
For the GPT and Claude services setting.

Currently, the prompt area is unadjustable and hard to read the whole text.
![image](https://github.com/user-attachments/assets/82ac2ed5-4fff-47f9-9b0b-7dd117986d9e)
