### PR TITLE
Fix #1156 by remove leading newlines

### DIFF
--- a/src/utils/str.ts
+++ b/src/utils/str.ts
@@ -31,6 +31,8 @@ export function stripEmptyLines(text: string, enabled: boolean): string {
   // Normalize line endings to \n
   const normalizedText = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 
-  // Replace multiple consecutive line breaks with a single one
-  return normalizedText.replace(/\n{2,}/g, "\n");
+  // Remove leading newlines, then replace all remaining newlines with spaces
+  const result = normalizedText.replace(/^\n+/, "").replace(/\n+/g, " ");
+
+  return result;
 }


### PR DESCRIPTION
fix: improve stripEmptyLines function to remove leading newlines and replace multiple newlines with spaces

Tested with `THUDM/GLM-Z1-9B-0414` 

![image](https://github.com/user-attachments/assets/89c29499-c7b0-4df8-b9af-7527d58635a1)
