### PR TITLE
feat: add priority-based sorting for translation services

### DIFF
--- a/src/elements/panel.ts
+++ b/src/elements/panel.ts
@@ -1,7 +1,11 @@
 import { config } from "../../package.json";
 import { PluginCEBase } from "./base";
 import { getPref, setPref } from "../utils/prefs";
-import { LANG_CODE, SERVICES } from "../utils/config";
+import {
+  LANG_CODE,
+  SERVICES,
+  getSortedServicesWithPriorities,
+} from "../utils/config";
 import {
   addTranslateTask,
   autoDetectLanguage,
@@ -35,7 +39,7 @@ export class TranslatorPanel extends PluginCEBase {
 <hbox id="engine" align="center">
   <menulist id="services" native="true">
     <menupopup>
-      ${SERVICES.filter((service) => service.type === "sentence")
+      ${getSortedServicesWithPriorities("sentence")
         .map(
           (service) => `
         <menuitem data-l10n-id="service-${service.id}" value="${service.id}" />

--- a/src/modules/preferenceWindow.ts
+++ b/src/modules/preferenceWindow.ts
@@ -1,5 +1,9 @@
 import { config, homepage } from "../../package.json";
-import { LANG_CODE, SERVICES } from "../utils/config";
+import {
+  LANG_CODE,
+  SERVICES,
+  getSortedServicesWithPriorities,
+} from "../utils/config";
 import { getString } from "../utils/locale";
 import { getPref, setPref } from "../utils/prefs";
 import { setServiceSecret, validateServiceSecret } from "../utils/secret";
@@ -47,15 +51,15 @@ function buildPrefsPane() {
       children: [
         {
           tag: "menupopup",
-          children: SERVICES.filter(
-            (service) => service.type === "sentence",
-          ).map((service) => ({
-            tag: "menuitem",
-            attributes: {
-              label: getString(`service-${service.id}`),
-              value: service.id,
-            },
-          })),
+          children: getSortedServicesWithPriorities("sentence").map(
+            (service) => ({
+              tag: "menuitem",
+              attributes: {
+                label: getString(`service-${service.id}`),
+                value: service.id,
+              },
+            }),
+          ),
         },
       ],
     },
@@ -82,15 +86,13 @@ function buildPrefsPane() {
       children: [
         {
           tag: "menupopup",
-          children: SERVICES.filter((service) => service.type === "word").map(
-            (service) => ({
-              tag: "menuitem",
-              attributes: {
-                label: getString(`service-${service.id}`),
-                value: service.id,
-              },
-            }),
-          ),
+          children: getSortedServicesWithPriorities("word").map((service) => ({
+            tag: "menuitem",
+            attributes: {
+              label: getString(`service-${service.id}`),
+              value: service.id,
+            },
+          })),
         },
       ],
     },

--- a/src/modules/tabpanel.ts
+++ b/src/modules/tabpanel.ts
@@ -1,6 +1,6 @@
 import { getLocaleID, getString } from "../utils/locale";
 import { config } from "../../package.json";
-import { SERVICES } from "../utils/config";
+import { SERVICES, getSortedServicesWithPriorities } from "../utils/config";
 import { getPref, setPref } from "../utils/prefs";
 import { getLastTranslateTask } from "../utils/task";
 import { TranslatorPanel } from "../elements/panel";
@@ -178,15 +178,15 @@ function buildExtraPanel(doc: Document) {
                   children: [
                     {
                       tag: "menupopup",
-                      children: SERVICES.filter(
-                        (service) => service.type === "sentence",
-                      ).map((service) => ({
-                        tag: "menuitem",
-                        attributes: {
-                          label: getString(`service-${service.id}`),
-                          value: service.id,
-                        },
-                      })),
+                      children: getSortedServicesWithPriorities("sentence").map(
+                        (service) => ({
+                          tag: "menuitem",
+                          attributes: {
+                            label: getString(`service-${service.id}`),
+                            value: service.id,
+                          },
+                        }),
+                      ),
                     },
                   ],
                 },

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -838,6 +838,40 @@ function mapISO6393to6391(code: string) {
   );
 }
 
+/**
+ * Get services sorted by priority (descending) with alphabetical sorting within each priority group
+ * @param type - The type of service to filter ("word" or "sentence")
+ * @param priorityMap - Optional map of service IDs to priority values (higher = higher priority)
+ * @returns Sorted array of services
+ */
+export function getSortedServicesWithPriorities(
+  type: "word" | "sentence",
+  priorityMap: Record<string, number> = {},
+) {
+  // Default priorities
+  const defaultPriorities: Record<string, number> = {
+    // Custom services get priority 20
+    customgpt1: 20,
+    customgpt2: 20,
+    customgpt3: 20,
+    // All other services default to 100
+  };
+
+  return SERVICES.filter((service) => service.type === type).sort((a, b) => {
+    // Get priorities (use custom priority if provided, otherwise use default)
+    const aPriority = priorityMap[a.id] ?? defaultPriorities[a.id] ?? 100;
+    const bPriority = priorityMap[b.id] ?? defaultPriorities[b.id] ?? 100;
+
+    // Sort by priority first (descending - higher priority first)
+    if (aPriority !== bPriority) {
+      return bPriority - aPriority;
+    }
+
+    // Within same priority, sort alphabetically by service ID
+    return a.id.localeCompare(b.id);
+  });
+}
+
 export const SVGIcon = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" width="16" height="16" xml:space="preserve">
 <style type="text/css">


### PR DESCRIPTION
There have been many API services supported, and sometimes it’s challenging to find them. 
This change helps to improve user friendly based on priority. Items with the same priority will be automatically sorted alphabetically. If needed, the items can be further prioritized, for example, by selecting the most commonly used service to display at the top. 

This sorting is done during rendering, so the order in the manifest file doesn’t matter. 
Custom API is set to be sink at bottom. 

Here is the expected results.
![image](https://github.com/user-attachments/assets/1537b397-f6c9-41c4-8725-bbd814c9432f)
