### PR TITLE
fix: update translation labels to include stripping 'thinking' context

### DIFF
--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -116,4 +116,4 @@ pref-about-version =
     .value = { $name } Version { $version } Build { $time }
 
 pref-advanced-stripEmptyLines =
-    .label = Strip empty lines from translation results
+    .label = Strip empty lines and thinking from translation results

--- a/addon/locale/it-IT/preferences.ftl
+++ b/addon/locale/it-IT/preferences.ftl
@@ -111,4 +111,4 @@ pref-about-version =
     .value = { $name } Versione { $version } Build { $time }
 
 pref-advanced-stripEmptyLines =
-    .label = Rimuovi le righe vuote dai risultati della traduzione
+    .label = Rimuovi le righe vuote e pensieri dai risultati della traduzione

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -111,7 +111,7 @@ pref-about-version =
     .value = { $name } 版本 { $version } Build { $time }
 
 pref-advanced-stripEmptyLines =
-    .label = 从翻译结果中删除空行
+    .label = 从翻译结果中删除空行和思考内容
 pref-service-manageKeys =
     .label = 密钥管理
 pref-service-manageKeys-hint =

--- a/src/utils/str.ts
+++ b/src/utils/str.ts
@@ -20,7 +20,7 @@ export function fill(
 }
 
 /**
- * Strip empty lines from text
+ * Strip empty lines and thinking tags from text
  * @param text Text to process
  * @param enabled Whether stripping is enabled
  * @returns Processed text
@@ -28,8 +28,13 @@ export function fill(
 export function stripEmptyLines(text: string, enabled: boolean): string {
   if (!text || !enabled) return text;
 
+  // Strip <think>...</think> tags and their content
+  const processedText = text.replace(/<think>[\s\S]*?<\/think>/gi, "");
+
   // Normalize line endings to \n
-  const normalizedText = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const normalizedText = processedText
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n");
 
   // Remove leading newlines, then replace all remaining newlines with spaces
   const result = normalizedText.replace(/^\n+/, "").replace(/\n+/g, " ");

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -19,7 +19,6 @@ export type FluentMessageId =
   | 'itemPaneSection-header'
   | 'itemPaneSection-openStandalone'
   | 'itemPaneSection-sidenav'
-  | 'sideBarIcon-title'
   | 'itemmenu-more-label'
   | 'itemmenu-retranslateAbstract-label'
   | 'itemmenu-retranslateTitle-label'
@@ -220,6 +219,7 @@ export type FluentMessageId =
   | 'service-youdao'
   | 'service-youdaodict'
   | 'service-youdaozhiyun'
+  | 'sideBarIcon-title'
   | 'status-translating'
   | 'swapLanguage'
   | 'translate';


### PR DESCRIPTION
Similar to Release v2.2.6 (https://github.com/windingwind/zotero-pdf-translate/commit/b29645f42ce8b3dadc9908151099888f3c0f090f), this PR helps people does not know how to use Regex and just simply get rid of thinking tag.

This pull request introduces changes to enhance the handling of translation results by stripping both empty lines and "thinking" tags from text. Updates include modifications to localization files for multiple languages and improvements to the `stripEmptyLines` function in the codebase.

### Localization updates:

* [`addon/locale/en-US/preferences.ftl`](diffhunk://#diff-8b21f73c3b3b782dff21e947b73d8dd2dde9553b53d7d7efbebd451dddc368afL119-R119): Updated the label for `pref-advanced-stripEmptyLines` to clarify that both empty lines and thinking content are stripped from translation results.
* [`addon/locale/it-IT/preferences.ftl`](diffhunk://#diff-6fbb7c2fb066da545149dd57e4606da07d34429935d916c244c7e26b6b626318L114-R114): Updated the Italian localization for `pref-advanced-stripEmptyLines` to reflect the same clarification.
* [`addon/locale/zh-CN/preferences.ftl`](diffhunk://#diff-d04c18892ed72223035966c81d45fafcad02d90913fa5e57f6591fe1c213f06fL114-R114): Updated the Chinese localization for `pref-advanced-stripEmptyLines` to include the removal of thinking content.

### Code functionality enhancement:

* [`src/utils/str.ts`](diffhunk://#diff-838f075c76e3d3e1a25d4fc301bc3c06b574b81fd953b237efa189dd5def5b3cL23-R37): Enhanced the `stripEmptyLines` function to strip `<think>...</think>` tags and their content from text, in addition to normalizing line endings and removing empty lines.



For example, when using `qwen3:32b`, 
**Before:**
<img width="1566" height="712" alt="Screenshot 2025-07-12 at 12 06 10 AM" src="https://github.com/user-attachments/assets/8ba42966-a437-4488-8088-92d75f54428d" />

**After:**
<img width="724" height="450" alt="Screenshot 2025-07-12 at 12 08 45 AM" src="https://github.com/user-attachments/assets/d1eb6221-c645-4022-9bee-378fce86221a" />

**Note:** The stripping process will be conducted after all responses have been received. Consequently, there will be a temporary display of the thinking context. Once the translation is received in full, the thinking tag will be deleted.

**Test Build:**
[translate-for-zotero.xpi.zip](https://github.com/user-attachments/files/21192790/translate-for-zotero.xpi.zip)
