### PR TITLE
fix: bg color for SentenceBySentence Translation

### DIFF
--- a/src/modules/prompt.ts
+++ b/src/modules/prompt.ts
@@ -135,7 +135,7 @@ export function registerPrompt() {
                   {
                     type: "mousemove",
                     listener: () => {
-                      const highlightColor = "#fee972";
+                      const highlightColor = "var(--tag-yellow)";
 
                       const twinNode = [
                         ...Array.from(
@@ -212,7 +212,7 @@ export function registerPrompt() {
           const subContainer = ztoolkit.UI.createElement(doc, "div", {
             styles: {
               padding: ".5em",
-              border: "1px solid #eee",
+              border: "1px solid var(--color-border)",
               overflowY: "auto",
               minWidth: "10em",
               minHeight: "5em",
@@ -245,7 +245,7 @@ export function registerPrompt() {
           styles: {
             height: direction == "row" ? "100%" : `${size}px`,
             width: direction == "column" ? "100%" : `${size}px`,
-            backgroundColor: "#f0f0f0",
+            backgroundColor: "var(--color-border)",
             cursor: direction == "column" ? "ns-resize" : "ew-resize",
           },
         });


### PR DESCRIPTION
To support dark mode

- Before this PR
<img width="500" alt="image" src="https://github.com/user-attachments/assets/ba1cb2fb-c38b-4054-adac-00ea85d2c0f8" />

<img width="500"  alt="ac13ca63-d918-4d98-9bb1-110f0522f4c0" src="https://github.com/user-attachments/assets/ad07845f-7058-4844-a582-cc20caf009de" />

- After this PR
<img width="500" alt="11939c0c-31fb-4336-a891-d3faeea41a1a" src="https://github.com/user-attachments/assets/64da5067-ae27-4ac8-b7c6-220718c533b9" />
<img width="500" alt="48993004-b4bd-4209-9109-219e7484889e" src="https://github.com/user-attachments/assets/7f286298-67e5-4b19-9edb-cf427c27ccb5" />
