### PR TITLE
fix: bg color for custom parameters setting, after #1226

### DIFF
--- a/src/modules/settings/gpt.ts
+++ b/src/modules/settings/gpt.ts
@@ -6,7 +6,7 @@ const INPUT_STYLES = {
   height: "32px",
   padding: "6px 8px",
   boxSizing: "border-box",
-  border: "1px solid #ccc",
+  border: "1px solid var(--color-border)",
   borderRadius: "4px",
 };
 
@@ -170,8 +170,8 @@ async function openCustomRequestDialog(
                         styles: {
                           textAlign: "left",
                           padding: "10px 8px",
-                          borderBottom: "2px solid #ddd",
-                          backgroundColor: "#f5f5f5",
+                          borderBottom: "2px solid var(--color-border)",
+                          backgroundColor: "var(--color-menu)",
                           fontWeight: "bold",
                         },
                         properties: {
@@ -184,8 +184,8 @@ async function openCustomRequestDialog(
                         styles: {
                           textAlign: "left",
                           padding: "10px 8px",
-                          borderBottom: "2px solid #ddd",
-                          backgroundColor: "#f5f5f5",
+                          borderBottom: "2px solid var(--color-border)",
+                          backgroundColor: "var(--color-menu)",
                           fontWeight: "bold",
                         },
                         properties: {


### PR DESCRIPTION
To support dark mode.

In addition, the `Add Parameter` button is ineffective for me. Could you take a look when you have a moment? @Chapoly1305