### PR TITLE
fix: 400/401 error for mtranserver service

### DIFF
--- a/src/modules/services/mtranserver.ts
+++ b/src/modules/services/mtranserver.ts
@@ -4,10 +4,10 @@ import { TranslateTaskProcessor } from "../../utils/task";
 export default <TranslateTaskProcessor>async function (data) {
   const url =
     (getPref("mtranserver.endpoint") as string) ||
-    "http://101.132.167.46:58080/translate";
+    "http://localhost:8989/translate";
   const xhr = await Zotero.HTTP.request("POST", `${url}`, {
     headers: {
-      authorization: `Bearer ${data.secret}`,
+      authorization: `${data.secret}`,
       "content-type": "application/json",
     },
     body: JSON.stringify({
@@ -36,9 +36,13 @@ function mapLang(lang: string) {
 }
 
 const LANG_MAP = {
-  "zh-CN": "zh",
-  "zh-HK": "zh",
-  "zh-MO": "zh",
-  "zh-SG": "zh",
-  "zh-TW": "zh",
+  "zh": "zh-Hans",
+  "zh-CN": "zh-Hans",
+  "zh-HK": "zh-Hant",
+  "zh-MO": "zh-Hant",
+  "zh-SG": "zh-Hans",
+  "zh-TW": "zh-Hant",
+  "en-GB": "en",
+  "en-US": "en",
+  "en-CA": "en",
 } as Record<string, string | undefined>;


### PR DESCRIPTION
- Set the general URL `http://localhost:8989/translate` to be the default.
- Current MTranServer does not support `zh`, and it is better to set the language to `zh-Hans`. This results 400 error for me. See https://github.com/xxnuo/MTranServer/issues/60

```diff
-  authorization: `Bearer ${data.secret}`,
+  authorization: `${data.secret}`,
```
- Authorization: your token https://github.com/xxnuo/MTranServer?tab=readme-ov-file#%E5%BC%80%E5%8F%91%E8%80%85%E6%8E%A5%E5%8F%A3 The current setting results 401 error for me.

I just tested it with the new version (v3.0.0) of MTranServer. Have you encountered these issues? @caisong