### PR TITLE
fix: incompatible with old DeepLX(API) settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The default service is Google Translate. Currently, we support:
 | Youdao Translate             | No **[Free]**                 | [100+?](https://ai.youdao.com/DOCSIRMA/html/%E8%87%AA%E7%84%B6%E8%AF%AD%E8%A8%80%E7%BF%BB%E8%AF%91/API%E6%96%87%E6%A1%A3/%E6%96%87%E6%9C%AC%E7%BF%BB%E8%AF%91%E6%9C%8D%E5%8A%A1/%E6%96%87%E6%9C%AC%E7%BF%BB%E8%AF%91%E6%9C%8D%E5%8A%A1-API%E6%96%87%E6%A1%A3.html) |
 | Bing                         | No **[Free]**                 | en-zh                                                                                                                                                                                                                                                              |
 | DeepLX                       | No **[Free]**                 | Based on [DeepLX](https://github.com/OwO-Network/DeepLX?tab=readme-ov-file)                                                                                                                                                                                        |
-| DeepLX(API)                  | No **[Require config]**       | [DeepL(custom)](https://github.com/KyleChoy/zotero-pdf-translate/blob/CustomDeepL/README.md) or other [DeepLX related projects](https://github.com/OwO-Network/DeepLX/blob/6db098eb8b57af98f8341d209e565715715278a3/README.md#related-projects)                    |
+| DeepLX(API)                  | No **[Require config]**       | [DeepLX](https://github.com/OwO-Network/DeepLX?tab=readme-ov-file) related projects                                                                                                                                                                                |
 | LibreTranslate               | Optional **[Require config]** | [LibreTranslate](https://github.com/LibreTranslate/LibreTranslate)                                                                                                                                                                                                 |
 | MTranServer                  | Optional **[Require config]** | [MTranServer](https://github.com/xxnuo/MTranServer)                                                                                                                                                                                                                |
 | Pot                          | No **[Require config]**       | [Pot](https://github.com/pot-app/pot-desktop) _Translate results show in Pot_                                                                                                                                                                                      |
@@ -154,7 +154,7 @@ The secret format is `MY_SECRET`.
 Apply [here](https://open.caiyunapp.com/%E4%BA%94%E5%88%86%E9%92%9F%E5%AD%A6%E4%BC%9A%E5%BD%A9%E4%BA%91%E5%B0%8F%E8%AF%91_API).
 
 **DeepL Translate**  
-Apply [here](https://www.deepl.com/pro?cta=header-prices/#developer).  
+Apply [official API](https://www.deepl.com/pro?cta=header-prices/#developer) or [third-party API](https://deepl-pro.com/#/translate).  
 The secret format is `secretToken` or `secretToken#glossaryId` (if you want to specify some translate glossary).
 
 **Aliyun Translate**  

--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -247,7 +247,7 @@
       <html:input
         type="text"
         preference="__prefsPrefix__.disabledLanguages"
-        style="min-width: 100px"
+        style="min-width: 80px"
       ></html:input>
     </hbox>
     <hbox align="center">
@@ -269,7 +269,7 @@
       <html:input
         type="text"
         preference="__prefsPrefix__.resultRegex"
-        style="min-width: 100px"
+        style="min-width: 80px"
       ></html:input>
     </hbox>
     <hbox align="center" style="gap: 8px">

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -81,7 +81,7 @@ pref(
 pref("__prefsPrefix__.cnkiSplitSecond", 1);
 pref("__prefsPrefix__.cnkiUseSplit", true);
 pref("__prefsPrefix__.deeplx.endpoint", "https://www2.deepl.com/jsonrpc");
-pref("__prefsPrefix__.deeplcustom.endpoint", "http://127.0.0.1:8080/translate");
+pref("__prefsPrefix__.deeplcustom.endpoint", "");
 pref("__prefsPrefix__.pot.port", 60828);
 pref(
   "__prefsPrefix__.qwenmt.endPoint",

--- a/src/modules/defaultPrefs.ts
+++ b/src/modules/defaultPrefs.ts
@@ -1,6 +1,6 @@
 import { getService, SERVICES } from "../utils/config";
 import { clearPref, getPref, getPrefJSON, setPref } from "../utils/prefs";
-import { setServiceSecret } from "../utils/secret";
+import { getServiceSecret, setServiceSecret } from "../utils/secret";
 
 export function setDefaultPrefSettings() {
   const isZhCN = Zotero.locale === "zh-CN";
@@ -24,6 +24,12 @@ export function setDefaultPrefSettings() {
     }
   }
   setPref("secretObj", JSON.stringify(secrets));
+
+  // From v2.2.22, migrate previous settings in secrets to prefs
+  const deeplxApiSecret = getServiceSecret("deeplcustom");
+  if (deeplxApiSecret) {
+    setPref("deeplcustom.endpoint", deeplxApiSecret);
+  }
 
   if (isZhCN && !getPref("disabledLanguages")) {
     setPref("disabledLanguages", "zh,zh-CN,中文;");

--- a/src/modules/defaultPrefs.ts
+++ b/src/modules/defaultPrefs.ts
@@ -27,7 +27,7 @@ export function setDefaultPrefSettings() {
 
   // From v2.2.22, migrate previous settings in secrets to prefs
   const deeplxApiSecret = getServiceSecret("deeplcustom");
-  if (deeplxApiSecret) {
+  if (deeplxApiSecret && !getPref("deeplcustom.endpoint")) {
     setPref("deeplcustom.endpoint", deeplxApiSecret);
   }
 

--- a/src/modules/services/deeplcustom.ts
+++ b/src/modules/services/deeplcustom.ts
@@ -2,9 +2,7 @@ import { TranslateTaskProcessor } from "../../utils/task";
 import { getPref } from "../../utils/prefs";
 
 export default <TranslateTaskProcessor>async function (data) {
-  const url =
-    (getPref("deeplcustom.endpoint") as string) ||
-    "http://127.0.0.1:8080/translate";
+  const url = (getPref("deeplcustom.endpoint") as string) || data.secret;
   const reqBody = JSON.stringify({
     text: data.raw,
     source_lang: data.langfrom.split("-")[0].toUpperCase(),

--- a/src/modules/services/deeplcustom.ts
+++ b/src/modules/services/deeplcustom.ts
@@ -2,7 +2,7 @@ import { TranslateTaskProcessor } from "../../utils/task";
 import { getPref } from "../../utils/prefs";
 
 export default <TranslateTaskProcessor>async function (data) {
-  const url = (getPref("deeplcustom.endpoint") as string) || data.secret;
+  const url = getPref("deeplcustom.endpoint") as string;
   const reqBody = JSON.stringify({
     text: data.raw,
     source_lang: data.langfrom.split("-")[0].toUpperCase(),

--- a/src/modules/services/mtranserver.ts
+++ b/src/modules/services/mtranserver.ts
@@ -36,7 +36,7 @@ function mapLang(lang: string) {
 }
 
 const LANG_MAP = {
-  "zh": "zh-Hans",
+  zh: "zh-Hans",
   "zh-CN": "zh-Hans",
   "zh-HK": "zh-Hant",
   "zh-MO": "zh-Hant",

--- a/src/modules/settings/deeplcustom.ts
+++ b/src/modules/settings/deeplcustom.ts
@@ -4,8 +4,7 @@ import { getPref, setPref } from "../../utils/prefs";
 export async function deeplcustomStatusCallback(status: boolean) {
   const dialog = new ztoolkit.Dialog(4, 1);
   const dialogData: { [key: string | number]: any } = {
-    endpoint:
-      getPref("deeplcustom.endpoint") || "http://127.0.0.1:8080/translate",
+    endpoint: getPref("deeplcustom.endpoint"),
   };
   dialog
     .setDialogData(dialogData)
@@ -61,7 +60,7 @@ export async function deeplcustomStatusCallback(status: boolean) {
     case "help":
       {
         Zotero.launchURL(
-          "https://github.com/KyleChoy/zotero-pdf-translate/blob/CustomDeepL/README.md",
+          "https://github.com/ramonmi/DeepLX-for-Zotero/blob/main/README_zh.md",
         );
       }
       break;


### PR DESCRIPTION
- Before v2.2.22, the EndPoint has been set in the Secret input box. 2.2.22 version changes it to Config-EndPoint to be unified with other 📍services. However, this may affect the user experience of some old users (manual changes are required when using a non-`http://127.0.0.1:8080/translate` API URL). This PR fixes it.
- Change the help documentation for DeepLX(API) and add the guide for another available DeepLX-related service.