### PR TITLE
fix: modify secret validator and clean code

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -18,19 +18,6 @@ export interface SecretValidateResult {
 export const SERVICES: Readonly<Readonly<TranslateService>[]> = <const>[
   {
     type: "sentence",
-    id: "libretranslate",
-    defaultSecret: "",
-    secretValidator(secret: string) {
-      // API key is optional in LibreTranslate
-      return {
-        secret,
-        status: true,
-        info: "",
-      };
-    },
-  },
-  {
-    type: "sentence",
     id: "googleapi",
   },
   {
@@ -52,6 +39,24 @@ export const SERVICES: Readonly<Readonly<TranslateService>[]> = <const>[
   {
     type: "sentence",
     id: "bing",
+  },
+  {
+    type: "sentence",
+    id: "deeplx",
+  },
+  {
+    type: "sentence",
+    id: "deeplcustom",
+  },
+  {
+    type: "sentence",
+    id: "libretranslate",
+    // API key is optional in LibreTranslate
+  },
+  {
+    type: "sentence",
+    id: "mtranserver",
+    // Token is optional in MTranServer
   },
   {
     type: "sentence",
@@ -138,10 +143,17 @@ export const SERVICES: Readonly<Readonly<TranslateService>[]> = <const>[
     id: "caiyun",
     defaultSecret: "3975l6lr5pcbvidl6jl2",
     secretValidator(secret: string) {
+      const flag = secret.length > 0;
+      const source = getService("caiyun");
       return {
         secret,
-        status: secret !== "",
-        info: "",
+        status: flag && secret !== source.defaultSecret,
+        info:
+          secret === source.defaultSecret
+            ? "The default secret is for testing only. You should set your own custom token for production."
+            : flag
+              ? ""
+              : "The secret is not set.",
       };
     },
   },
@@ -174,22 +186,6 @@ export const SERVICES: Readonly<Readonly<TranslateService>[]> = <const>[
           : `The secret is your DeepL (pro plan) KEY. The secret length must >= 36, but got ${secret?.length}.`,
       };
     },
-  },
-  {
-    type: "sentence",
-    id: "deeplcustom",
-    defaultSecret: "",
-    secretValidator(secret: string) {
-      return {
-        secret,
-        status: true,
-        info: "",
-      };
-    },
-  },
-  {
-    type: "sentence",
-    id: "deeplx",
   },
   {
     type: "sentence",
@@ -482,19 +478,6 @@ ProjectId: ${parts?.[3] || "0"}`;
           : status
             ? "Click the button to check connectivity."
             : "The Claude API key format might be invalid. Typically starts with 'sk-ant-'.",
-      };
-    },
-  },
-  {
-    type: "sentence",
-    id: "mtranserver",
-    defaultSecret: "",
-    secretValidator(secret: string) {
-      // Token is optional in MTranServer
-      return {
-        secret,
-        status: true,
-        info: "",
       };
     },
   },


### PR DESCRIPTION
- Clean the secretValidator code for the 📍 services that need no secret. Sort the code block.
- Add a hint for the default secret of the Caiyun service.