### PR TITLE
fix: ineffective clean button after translating non-text raw

### DIFF
--- a/src/elements/panel.ts
+++ b/src/elements/panel.ts
@@ -408,7 +408,10 @@ export class TranslatorPanel extends PluginCEBase {
     // For manually update translation task
     this._taskID = lastTask.id;
 
-    if (lastTask.type === "text") {
+    if (
+      lastTask.type === "text" ||
+      (lastTask.raw === "" && lastTask.result === "")
+    ) {
       setValue("raw-text", reverseRawResult ? lastTask.result : lastTask.raw);
       setValue(
         "result-text",


### PR DESCRIPTION
After https://github.com/windingwind/zotero-pdf-translate/commit/33be40705b7ecb9e1228ebf09d02eac64744d695.

Reproduce step: 
1. Translate some text
2. Translate annotations or other non-text raw
3. Click the `Clean` button in the item pane. The item pane text area remains `lastTextTask`'s raw and result.

With this PR, despite the result in the extra panel of the standalone window remaining, it's not a big deal.