### PR TITLE
fix: pop-up ui with enabled concat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ If there are complex options, please bind a callback in `src/modules/settings/in
 
 Use this code under AGPL. No warranties are provided. Keep the laws of your locality in mind!
 
-## My Other Zotero Plugins
+## My Other Zotero Addons
 
 - [Better Notes](https://github.com/windingwind/zotero-better-notes): Everything about note management. All in Zotero.
 - [Actions & Tags](https://github.com/windingwind/zotero-tag): Automatically tag items/Batch tagging

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ If there are complex options, please bind a callback in `src/modules/settings/in
 
 Use this code under AGPL. No warranties are provided. Keep the laws of your locality in mind!
 
-## My Other Zotero Addons
+## My Other Zotero Plugins
 
 - [Better Notes](https://github.com/windingwind/zotero-better-notes): Everything about note management. All in Zotero.
 - [Actions & Tags](https://github.com/windingwind/zotero-tag): Automatically tag items/Batch tagging

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -46,7 +46,7 @@ export function updateReaderPopup() {
     updateHidden(addToNoteButton, true);
     return;
   }
-  const task = getLastTranslateTask();
+  const task = getLastTranslateTask({ type: "text" });
   if (!task) {
     return;
   }

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -85,10 +85,7 @@ export function updateReaderPopup() {
     audio.play();
   }
 
-  const selection = addon.data.translate.selectedText;
-  const hideTranslateButton =
-    task.status !== "waiting" && task.raw === selection;
-
+  const hideTranslateButton = task.status !== "waiting";
   updateHidden(translateButton, hideTranslateButton);
 
   textarea.hidden = hidePopupTextarea || !hideTranslateButton;

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -171,6 +171,7 @@ export function addTranslateTask(
   if (isConcatMode && lastTask) {
     lastTask.raw += " " + raw;
     lastTask.extraTasks.forEach((extraTask) => (extraTask.raw += " " + raw));
+    lastTask.status = "waiting";
     return;
   }
   // Create a new task

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -172,6 +172,7 @@ export function addTranslateTask(
     lastTask.raw += " " + raw;
     lastTask.extraTasks.forEach((extraTask) => (extraTask.raw += " " + raw));
     lastTask.status = "waiting";
+    putTranslateTaskAtHead(lastTask.id);
     return;
   }
   // Create a new task


### PR DESCRIPTION
- Resolve https://github.com/windingwind/zotero-pdf-translate/pull/1264#discussion_r2259646726

**Disable Auto-Trans Selection** and **Enable concat mode**
The previous scheme results in a persistent Translate button and a hidden pop-up text area.

---

- Another issue
    - If we highlighted an annotation and auto-trans it with the concat mode enabled. Then, select some new text, and the annotation translation result will be displayed in the pop-up rather than the Translate button. Triggering` Ctrl/Cmd+T` or clicking the Translate button in the item pane will re-translate the annotation.

**Actually, it might be the wrong way to use the concat mode (highlight annotation and auto-trans with enabled concat mode)**, so I think it is ok to keep it there.