### PR TITLE
chore: save defaults to Prefs when Tencent values are unset

### DIFF
--- a/src/modules/settings/tencent.ts
+++ b/src/modules/settings/tencent.ts
@@ -1,6 +1,7 @@
 import { getPref, setPref } from "../../utils/prefs";
 import { getString } from "../../utils/locale";
 import { getService } from "../../utils/config";
+import { getServiceSecret, setServiceSecret } from "../../utils/secret";
 
 export async function tencentStatusCallback(status: boolean) {
   const dialog = new ztoolkit.Dialog(2, 1);
@@ -16,8 +17,7 @@ export async function tencentStatusCallback(status: boolean) {
   // If individual preferences are not set, try to parse from the main secret
   if (!secretId || !secretKey) {
     try {
-      const secrets = JSON.parse((getPref("secretObj") as string) || "{}");
-      const tencentSecret = secrets.tencent;
+      const tencentSecret = getServiceSecret("tencent");
 
       if (typeof tencentSecret === "string") {
         // Legacy format - parse it
@@ -366,10 +366,8 @@ export async function tencentStatusCallback(status: boolean) {
           sentRepoIDList: sentRepoList,
         };
 
-        // Update the main secret storage
-        const secrets = JSON.parse(getPref("secretObj") as string);
-        secrets.tencent = secretConfig;
-        setPref("secretObj", JSON.stringify(secrets));
+        // Update the tencent secret storage
+        setServiceSecret("tencent", JSON.stringify(secretConfig));
       }
       break;
     case "help":

--- a/src/modules/settings/tencent.ts
+++ b/src/modules/settings/tencent.ts
@@ -1,5 +1,6 @@
 import { getPref, setPref } from "../../utils/prefs";
 import { getString } from "../../utils/locale";
+import { getService } from "../../utils/config";
 
 export async function tencentStatusCallback(status: boolean) {
   const dialog = new ztoolkit.Dialog(2, 1);
@@ -321,11 +322,27 @@ export async function tencentStatusCallback(status: boolean) {
           return;
         }
 
+        // Set default values in defaultSecret to Prefs when clicking Save button
+        const tencentDefaultSecret = getService("tencent").defaultSecret;
+        const regionPlaceHolder = tencentDefaultSecret?.split("#")[2];
+        const projectIdPlaceHolder = tencentDefaultSecret?.split("#")[3];
+        const regionValue = dialogData.region
+          ? regionPlaceHolder && regionPlaceHolder === dialogData.region
+            ? "ap-shanghai"
+            : dialogData.region
+          : "ap-shanghai";
+        const projectIdValue = dialogData.projectId
+          ? projectIdPlaceHolder &&
+            projectIdPlaceHolder === dialogData.projectId
+            ? "0"
+            : dialogData.projectId
+          : "0";
+
         // Save individual preferences
         setPref("tencent.secretId", dialogData.secretId);
         setPref("tencent.secretKey", dialogData.secretKey);
-        setPref("tencent.region", dialogData.region || "ap-shanghai");
-        setPref("tencent.projectId", dialogData.projectId || "0");
+        setPref("tencent.region", regionValue);
+        setPref("tencent.projectId", projectIdValue);
         setPref("tencent.termRepoIDList", dialogData.termRepoIDList || "");
         setPref("tencent.sentRepoIDList", dialogData.sentRepoIDList || "");
 
@@ -343,8 +360,8 @@ export async function tencentStatusCallback(status: boolean) {
         const secretConfig = {
           secretId: dialogData.secretId,
           secretKey: dialogData.secretKey,
-          region: dialogData.region || "ap-shanghai",
-          projectId: dialogData.projectId || "0",
+          region: regionValue,
+          projectId: projectIdValue,
           termRepoIDList: termRepoList,
           sentRepoIDList: sentRepoList,
         };


### PR DESCRIPTION
This PR fixes the following case:

- Click the `Config` button and input the Secret ID and Secret Key, click the `Save` button without any other selection/input.
- In the previous version, if the user forgets (or does not realize that this is a necessary modification) to select the Region and input the Project ID, an error occurs when using the Tencent service to translate.

BTW, use native functions to simplify code.