### PR TITLE
chore: set CNKI as default service for China mainland

### DIFF
--- a/src/modules/defaultPrefs.ts
+++ b/src/modules/defaultPrefs.ts
@@ -7,7 +7,7 @@ export function setDefaultPrefSettings() {
   const servicesIds = SERVICES.map((service) => service.id);
   if (!servicesIds.includes((getPref("translateSource") as string) || "")) {
     // Google Translate is not accessible in China mainland
-    setPref("translateSource", isZhCN ? "haici" : "googleapi");
+    setPref("translateSource", isZhCN ? "cnki" : "googleapi");
   }
   if (!servicesIds.includes((getPref("dictSource") as string) || "")) {
     setPref("dictSource", isZhCN ? "bingdict" : "freedictionaryapi");


### PR DESCRIPTION
The previous default-free service, Haici, is no longer available.
Re https://github.com/windingwind/zotero-pdf-translate/issues/1202, https://github.com/windingwind/zotero-pdf-translate/issues/1221#issuecomment-3063456710