### PR TITLE
docs: add hint for the region in Microsoft secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The secret format is `MY_APIKEY#dictNo(optional)#memoryNo(optional)`.
 
 **Microsoft Translate**  
 Apply [here](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/quickstart-translator?tabs=csharp). Copy your secret and paste it into the settings.  
-The secret format is `MY_SECRET`.
+The secret format is `serviceKEY#region(required if the region is not global)`.
 
 > See [this issue](https://github.com/windingwind/zotero-pdf-translate/issues/3#issuecomment-1064688597) for detailed steps to set up the Microsoft Translate.
 

--- a/src/modules/services/microsoft.ts
+++ b/src/modules/services/microsoft.ts
@@ -41,14 +41,14 @@ export const Microsoft: TranslateService = {
   defaultSecret: "",
   secretValidator(secret: string) {
     const params = secret.split("#");
-    const secretKey = params[0];
-    const flag = secretKey?.length === 32 || secretKey?.length === 84;
+    const serviceKey = params[0];
+    const flag = serviceKey?.length === 32 || serviceKey?.length === 84;
     return {
       secret,
       status: flag,
       info: flag
         ? ""
-        : `The secret is your Azure translate serviceKEY#region(required if the region is not global). The secretKEY length must be 32 or 84, but got ${secretKey?.length}.`,
+        : `The secret is your Azure translate serviceKEY#region(required if the region is not global). The serviceKEY length must be 32 or 84, but got ${serviceKey?.length}.`,
     };
   },
   translate,


### PR DESCRIPTION
Now, new users can't choose the Global region when registering a new Microsoft secret. Resolve https://github.com/windingwind/zotero-pdf-translate/issues/950#issuecomment-2513766014