### PR TITLE
fix: gpt service error since settings refactor introduced pref type issue

### DIFF
--- a/src/modules/services/gpt.ts
+++ b/src/modules/services/gpt.ts
@@ -70,13 +70,10 @@ const gptTranslate = async function (
     langTo: string,
     sourceText: string,
   ) {
-    return (
-      getPref(`${prefix}.prompt`) ||
-      ""
-        .replaceAll("${langFrom}", langFrom)
-        .replaceAll("${langTo}", langTo)
-        .replaceAll("${sourceText}", sourceText)
-    );
+    return ((getPref(`${prefix}.prompt`) as string) || "")
+      .replaceAll("${langFrom}", langFrom)
+      .replaceAll("${langTo}", langTo)
+      .replaceAll("${sourceText}", sourceText);
   }
 
   const streamMode = stream ?? true;

--- a/src/utils/settingsDialog.ts
+++ b/src/utils/settingsDialog.ts
@@ -146,30 +146,44 @@ class ServiceSettingsDialog extends SettingsDialogHelper {
   }
 
   addNumberSetting(field: InputFieldNumber): AllowedSettingsMethods {
-    return this.addSetting(getString(field.nameKey), field.prefKey, {
-      tag: "input",
-      attributes: {
-        type: "number",
-        min: field.min || 0,
-        max: field.max || 100,
-        step: field.step || 1,
+    return this.addSetting(
+      getString(field.nameKey),
+      field.prefKey,
+      {
+        tag: "input",
+        attributes: {
+          type: "number",
+          min: field.min || 0,
+          max: field.max || 100,
+          step: field.step || 1,
+        },
+        styles: {
+          minWidth: "400px",
+        },
       },
-      styles: {
-        minWidth: "400px",
+      {
+        valueType: "number",
       },
-    });
+    );
   }
 
   addCheckboxSetting(field: CheckboxField): AllowedSettingsMethods {
-    return this.addSetting(getString(field.nameKey), field.prefKey, {
-      tag: "input",
-      attributes: {
-        type: "checkbox",
+    return this.addSetting(
+      getString(field.nameKey),
+      field.prefKey,
+      {
+        tag: "input",
+        attributes: {
+          type: "checkbox",
+        },
+        styles: {
+          justifySelf: "start",
+        },
       },
-      styles: {
-        justifySelf: "start",
+      {
+        valueType: "boolean",
       },
-    });
+    );
   }
 
   addSelectSetting(field: SelectField): AllowedSettingsMethods {


### PR DESCRIPTION
- The toolkit does not automatically infer boolean from input>checkbox, so it needs to be specified manually.
- The prompt is missing `()`, causing the order to be incorrect.