### PR TITLE
fix: update Gemini endpoint to version 2.5

### DIFF
--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -70,7 +70,7 @@ pref("__prefsPrefix__.azureGPT.stream", true);
 pref("__prefsPrefix__.azureGPT.customParams", "");
 pref(
   "__prefsPrefix__.gemini.endPoint",
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest",
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite",
 );
 pref(
   "__prefsPrefix__.gemini.prompt",


### PR DESCRIPTION
Change default gemini endpoint for resolving 

- https://github.com/windingwind/zotero-pdf-translate/issues/1335
- https://github.com/windingwind/zotero-pdf-translate/issues/1322