### PR TITLE
fix: apply RTL formatting based on langTo in popup, fixes #1365

### DIFF
--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -88,6 +88,16 @@ export function updateReaderPopup() {
   const hideTranslateButton = task.status !== "waiting";
   updateHidden(translateButton, hideTranslateButton);
 
+  switch (task.langto?.split("-")[0]) {
+    case "ar":
+    case "fa":
+    case "he":
+      textarea.style.direction = "rtl";
+      break;
+    default:
+      textarea.style.direction = "ltr";
+  }
+
   textarea.hidden = hidePopupTextarea || !hideTranslateButton;
   textarea.value = task.result || task.raw;
   textarea.style.fontSize = `${getPref("fontSize")}px`;


### PR DESCRIPTION
- For non-RTL locales (i.e., not ar, fa, or he), the textarea (the type of Popup, rather than editable-text) defaults to LTR, even if the target language of the translation is one of them.
- This PR sets the RTL mode explicitly, depending on the target language.