### PR TITLE
Fix/cnki retry for #1383

### DIFF
--- a/src/modules/services/cnki.ts
+++ b/src/modules/services/cnki.ts
@@ -2,6 +2,28 @@ import { aesEcbEncrypt, base64 } from "../../utils/crypto";
 import { getPref, getPrefJSON, setPref } from "../../utils/prefs";
 import { TranslateService } from "./base";
 
+async function requestWithRetry<T>(
+  fn: () => Promise<T>,
+  retries: number,
+  baseDelayMs: number,
+) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastError = e;
+      if (attempt === retries) {
+        throw e;
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, baseDelayMs * (attempt + 1)),
+      );
+    }
+  }
+  throw lastError;
+}
+
 const translate = <TranslateService["translate"]>async function (data) {
   let progressWindow;
   const useSplit = getPref("cnkiUseSplit") as boolean;
@@ -11,20 +33,26 @@ const translate = <TranslateService["translate"]>async function (data) {
   }
 
   const processTranslation = async (text: string) => {
-    const xhr = await Zotero.HTTP.request(
-      "POST",
-      "https://dict.cnki.net/fyzs-front-api/translate/literaltranslation",
-      {
-        headers: {
-          "Content-Type": "application/json;charset=UTF-8",
-          Token: await getToken(),
-        },
-        body: JSON.stringify({
-          words: await getWord(text),
-          translateType: null,
-        }),
-        responseType: "json",
-      },
+    const token = await getToken();
+    const xhr = await requestWithRetry(
+      () =>
+        Zotero.HTTP.request(
+          "POST",
+          "https://dict.cnki.net/fyzs-front-api/translate/literaltranslation",
+          {
+            headers: {
+              "Content-Type": "application/json;charset=UTF-8",
+              Token: token,
+            },
+            body: JSON.stringify({
+              words: await getWord(text),
+              translateType: null,
+            }),
+            responseType: "json",
+          },
+        ),
+      2,
+      500,
     );
 
     if (xhr.response.data?.isInputVerificationCode) {
@@ -95,12 +123,17 @@ export async function getToken(forceRefresh: boolean = false) {
     ztoolkit.log(e);
   }
   if (doRefresh) {
-    const xhr = await Zotero.HTTP.request(
-      "GET",
-      "https://dict.cnki.net/fyzs-front-api/getToken",
-      {
-        responseType: "json",
-      },
+    const xhr = await requestWithRetry(
+      () =>
+        Zotero.HTTP.request(
+          "GET",
+          "https://dict.cnki.net/fyzs-front-api/getToken",
+          {
+            responseType: "json",
+          },
+        ),
+      2,
+      300,
     );
     if (xhr && xhr.response && xhr.response.code === 200) {
       token = xhr.response.token;

--- a/src/modules/services/cnki.ts
+++ b/src/modules/services/cnki.ts
@@ -14,6 +14,7 @@ async function requestWithRetry<T>(
     } catch (e) {
       lastError = e;
       if (attempt === retries) {
+        ztoolkit.log(`CNKI request failed after ${retries + 1} attempts`, e);
         throw e;
       }
       await new Promise((resolve) =>
@@ -35,7 +36,7 @@ const translate = <TranslateService["translate"]>async function (data) {
   const processTranslation = async (text: string) => {
     const token = await getToken();
     const xhr = await requestWithRetry(
-      () =>
+      async () =>
         Zotero.HTTP.request(
           "POST",
           "https://dict.cnki.net/fyzs-front-api/translate/literaltranslation",


### PR DESCRIPTION
This pull request improves the resilience of the CNKI translation service by introducing a generic retry mechanism for HTTP requests. The main changes are the addition of a reusable `requestWithRetry` helper and its integration into the token fetching and translation request flows.

**Reliability improvements:**

* Added a new `requestWithRetry` helper function to handle automatic retries for asynchronous operations, improving robustness against transient network errors.
* Updated the translation request in `processTranslation` to use `requestWithRetry`, retrying failed requests up to two times with exponential backoff.
* Modified the `getToken` function to use `requestWithRetry` for token fetching, adding retries to the token acquisition process.