### PR TITLE
fix popup cmd a select all for #1395

### DIFF
--- a/addon/chrome/content/standalone.xhtml
+++ b/addon/chrome/content/standalone.xhtml
@@ -29,7 +29,7 @@
   </xul:linkset>
 
   <xul:commandset id="mainCommandSet">
-    <xul:command id="cmd_close" oncommand="window.close();" />
+    <xul:command id="cmd_close" oncommand="window.close()" />
   </xul:commandset>
   <xul:keyset id="mainKeyset">
     <xul:key

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -139,6 +139,7 @@ export function buildReaderPopup(
 
   const makeId = (type: string) =>
     `${config.addonRef}-${reader._instanceID}-${type}`;
+  const onTextAreaCopy = getOnTextAreaCopy(popup, makeId("text"));
 
   const hidePopupTextarea = getPref("enableHidePopupTextarea") as boolean;
   append(
@@ -243,6 +244,10 @@ export function buildReaderPopup(
                   onTextAreaResize as (ev: Event) => void,
                 );
               },
+            },
+            {
+              type: "keydown",
+              listener: onTextAreaCopy as (ev: Event) => void,
             },
             {
               type: "dblclick",


### PR DESCRIPTION
Root cause was missing event wiring: the popup textarea’s keydown handler (getOnTextAreaCopy) was no longer attached after refactor, so Cmd/Ctrl+A logic in that handler never ran. metaKey detection itself was fine; it just wasn’t being invoked in the popup textarea. getOnTextAreaCopy(...) centralizes Cmd/Ctrl+A/C/X behavior in one place.
It avoids duplicating shortcut logic across multiple inline listeners.

**Test results:** now user able to use select all in the pop-up, as well as copy, cut, etc. Concat feature works as before, not affected by this fix.

<img width="881" height="636" alt="image" src="https://github.com/user-attachments/assets/2e685561-6d33-436a-a981-886fe09d41f1" />
