### PR TITLE
fix: mask access tokens in translation logs

### DIFF
--- a/src/modules/services/index.ts
+++ b/src/modules/services/index.ts
@@ -3,6 +3,7 @@ import {
   getString,
   getPref,
   getLastTranslateTask,
+  sanitizeTaskForLog,
   TranslateTask,
   TranslateTaskRunner,
   stripEmptyLines,
@@ -294,7 +295,7 @@ export class TranslationServices {
 
       if (cachedTask) {
         cacheHit = true;
-        ztoolkit.log("cache hit", cachedTask);
+        ztoolkit.log("cache hit", sanitizeTaskForLog(cachedTask));
         task.result = cachedTask.result;
         task.status = "success";
 

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -118,9 +118,9 @@ export function sanitizeTaskForLog(task: TranslateTask): TranslateTask {
   return {
     ...task,
     ...(task.secret ? { secret: maskAccessToken(task.secret) } : {}),
-    extraTasks: task.extraTasks?.map((extraTask) =>
+    extraTasks: ((task.extraTasks ?? []).map((extraTask) =>
       sanitizeTaskForLog(extraTask),
-    ) as TranslateTask[] & { extraTasks: [] }[],
+    ) as TranslateTask["extraTasks"]),
   };
 }
 

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -96,6 +96,34 @@ export type TranslateTaskProcessor = (
   data: Required<TranslateTask>,
 ) => Promise<void> | void;
 
+function maskAccessToken(token: string): string {
+  if (!token) return token;
+
+  const length = token.length;
+  if (length <= 2) return "*".repeat(length);
+
+  const visible = length <= 6 ? 1 : 3;
+  const maskedLength = length - visible * 2;
+
+  if (maskedLength <= 0) {
+    return "*".repeat(length);
+  }
+
+  return `${token.slice(0, visible)}${"*".repeat(maskedLength)}${token.slice(
+    length - visible,
+  )}`;
+}
+
+export function sanitizeTaskForLog(task: TranslateTask): TranslateTask {
+  return {
+    ...task,
+    ...(task.secret ? { secret: maskAccessToken(task.secret) } : {}),
+    extraTasks: task.extraTasks?.map((extraTask) =>
+      sanitizeTaskForLog(extraTask),
+    ) as TranslateTask[] & { extraTasks: [] }[],
+  };
+}
+
 export class TranslateTaskRunner {
   protected processor: TranslateTaskProcessor;
   constructor(processor: TranslateTaskProcessor) {
@@ -128,7 +156,7 @@ export class TranslateTaskRunner {
     data.secret = getServiceSecret(data.service);
     data.status = "processing";
     try {
-      ztoolkit.log(data);
+      ztoolkit.log(sanitizeTaskForLog(data));
       await this.processor(data as Required<TranslateTask>);
       data.status = "success";
     } catch (e) {


### PR DESCRIPTION
Masking  Policy
- Only applied when logging `TranslateTask` objects (task start log and `cache hit` log).
- Only `secret` fields are masked (including nested `extraTasks[].secret`).
- Mask format:
  - Keep at most first 3 and last 3 characters visible.
  - Replace the middle with `*`.
  - Keep total string length unchanged.
- Edge cases:
  - length `<= 2`: all `*`
  - length `3..6`: keep first 1 and last 1, middle masked
  - length `>= 7`: keep first 3 and last 3, middle masked

Example:  
`cr_90a249ab...a3cde37` style token (len 67) -> `cr_*************************************************************e37`

**Before:**
<img width="1000" height="72" alt="Screenshot 2026-04-11 at 8 12 25 PM" src="https://github.com/user-attachments/assets/d2e61e9c-746c-4250-b136-093994958348" />

**After:**
<img width="989" height="68" alt="Screenshot 2026-04-11 at 8 14 21 PM" src="https://github.com/user-attachments/assets/e118ca43-205d-4ae1-829c-1203ea4f8a07" />
