### PR TITLE
fix: bind abstract menu visibility to correct pref

### DIFF
--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -32,7 +32,7 @@ export function registerMenu() {
         onShowing: (event, context) => {
           context.setVisible(
             !!(
-              getPref("showItemMenuTitleTranslation") &&
+              getPref("showItemMenuAbstractTranslation") &&
               context.items?.every((item) => item.isRegularItem())
             ),
           );

--- a/src/modules/menu.ts
+++ b/src/modules/menu.ts
@@ -32,7 +32,7 @@ export function registerMenu() {
         onShowing: (event, context) => {
           context.setVisible(
             !!(
-              getPref("showItemMenuAbstractTranslation") &&
+              getPref("showItemMenuTitleTranslation") &&
               context.items?.every((item) => item.isRegularItem())
             ),
           );
@@ -56,7 +56,7 @@ export function registerMenu() {
         onShowing: (event, context) => {
           context.setVisible(
             !!(
-              getPref("showItemMenuTitleTranslation") &&
+              getPref("showItemMenuAbstractTranslation") &&
               context.items?.every((item) => item.isRegularItem())
             ),
           );


### PR DESCRIPTION
This PR fixes https://github.com/windingwind/zotero-pdf-translate/issues/1407 a preference-binding bug in the item context menu visibility logic.

In v2.4.3, the Translate Abstract menu item incorrectly checked showItemMenuTitleTranslation instead of showItemMenuAbstractTranslation in its onShowing handler. As a result: Disabling Title Translation hid both menu items. Toggling Abstract Translation had no effect on the abstract menu item visibility.

