### PR TITLE
Fix/1400 youdao translate bug

### DIFF
--- a/addon/chrome/content/standalone.xhtml
+++ b/addon/chrome/content/standalone.xhtml
@@ -29,7 +29,7 @@
   </xul:linkset>
 
   <xul:commandset id="mainCommandSet">
-    <xul:command id="cmd_close" oncommand="window.close();" />
+    <xul:command id="cmd_close" oncommand="window.close()" />
   </xul:commandset>
   <xul:keyset id="mainKeyset">
     <xul:key

--- a/src/modules/preferenceWindow.ts
+++ b/src/modules/preferenceWindow.ts
@@ -2,7 +2,7 @@ import { config, homepage } from "../../package.json";
 import { LANG_CODE } from "../utils/config";
 import { getString } from "../utils/locale";
 import { getPref, setPref } from "../utils/prefs";
-import { setServiceSecret, validateServiceSecret } from "../utils/secret";
+import { getServiceSecret, setServiceSecret, validateServiceSecret } from "../utils/secret";
 import { createServiceSettingsDialog } from "../utils";
 import { services } from "./services";
 
@@ -220,13 +220,13 @@ function buildPrefsPane() {
 
   doc
     .querySelector(`#${makeId("sentenceServicesSecret")}`)
-    ?.addEventListener("input", (e: Event) => {
+    ?.addEventListener("blur", (e: Event) => {
       onPrefsEvents("updateSentenceSecret");
     });
 
   doc
     .querySelector(`#${makeId("wordServicesSecret")}`)
-    ?.addEventListener("input", (e: Event) => {
+    ?.addEventListener("blur", (e: Event) => {
       onPrefsEvents("updateWordSecret");
     });
 
@@ -376,14 +376,15 @@ function onPrefsEvents(type: string, fromElement: boolean = true) {
       break;
     case "updateSentenceSecret":
       {
-        setServiceSecret(
-          getPref("translateSource") as string,
-          (
-            doc.querySelector(
-              `#${makeId("sentenceServicesSecret")}`,
-            ) as HTMLInputElement
-          ).value,
-        );
+        const serviceId = getPref("translateSource") as string;
+        const inputElem = doc.querySelector(
+          `#${makeId("sentenceServicesSecret")}`,
+        ) as HTMLInputElement;
+        const trimmedValue = inputElem.value.trim();
+        if (trimmedValue !== inputElem.value) {
+          setServiceSecret(serviceId, trimmedValue);
+          inputElem.value = trimmedValue;
+        }
       }
       break;
     case "setSentenceSecret":
@@ -435,14 +436,15 @@ function onPrefsEvents(type: string, fromElement: boolean = true) {
       break;
     case "updateWordSecret":
       {
-        setServiceSecret(
-          getPref("dictSource") as string,
-          (
-            doc.querySelector(
-              `#${makeId("wordServicesSecret")}`,
-            ) as HTMLInputElement
-          ).value,
-        );
+        const serviceId = getPref("dictSource") as string;
+        const inputElem = doc.querySelector(
+          `#${makeId("wordServicesSecret")}`,
+        ) as HTMLInputElement;
+        const trimmedValue = inputElem.value.trim();
+        if (trimmedValue !== inputElem.value) {
+          setServiceSecret(serviceId, trimmedValue);
+          inputElem.value = trimmedValue;
+        }
       }
       break;
     case "setWordSecret":

--- a/src/modules/preferenceWindow.ts
+++ b/src/modules/preferenceWindow.ts
@@ -2,7 +2,11 @@ import { config, homepage } from "../../package.json";
 import { LANG_CODE } from "../utils/config";
 import { getString } from "../utils/locale";
 import { getPref, setPref } from "../utils/prefs";
-import { getServiceSecret, setServiceSecret, validateServiceSecret } from "../utils/secret";
+import {
+  getServiceSecret,
+  setServiceSecret,
+  validateServiceSecret,
+} from "../utils/secret";
 import { createServiceSettingsDialog } from "../utils";
 import { services } from "./services";
 

--- a/src/utils/secret.ts
+++ b/src/utils/secret.ts
@@ -22,7 +22,7 @@ export function setServiceSecret(serviceId: string, secret: string) {
   } catch (e) {
     secrets = {};
   }
-  secrets[serviceId] = secret;
+  secrets[serviceId] = secret.trim();
   setPref("secretObj", JSON.stringify(secrets));
 }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where leading youdaozhiyun translator (maybe more translators)  api response 108 (youdaozhiyun's error code).
## Changes
- Add trim() in src/utils/secret.ts
- Changed secret input event from `input` to `blur` to avoid interrupting user typing
- Automatically trim leading/trailing spaces on focus loss and persist to `secretObj`
- Only perform save and update when value actually changes

## Related Issues

Fixes #1400  (if applicable)
