### PR TITLE
Fix/1418 secret save regression

### DIFF
--- a/src/modules/preferenceWindow.ts
+++ b/src/modules/preferenceWindow.ts
@@ -406,8 +406,10 @@ function onPrefsEvents(type: string, fromElement: boolean = true) {
         ) as HTMLInputElement;
         const trimmedValue = inputElem.value.trim();
         if (trimmedValue !== inputElem.value) {
-          setServiceSecret(serviceId, trimmedValue);
           inputElem.value = trimmedValue;
+        }
+        if (trimmedValue !== getServiceSecret(serviceId)) {
+          setServiceSecret(serviceId, trimmedValue);
         }
       }
       break;
@@ -466,8 +468,10 @@ function onPrefsEvents(type: string, fromElement: boolean = true) {
         ) as HTMLInputElement;
         const trimmedValue = inputElem.value.trim();
         if (trimmedValue !== inputElem.value) {
-          setServiceSecret(serviceId, trimmedValue);
           inputElem.value = trimmedValue;
+        }
+        if (trimmedValue !== getServiceSecret(serviceId)) {
+          setServiceSecret(serviceId, trimmedValue);
         }
       }
       break;

--- a/src/modules/settings/manageKeys.ts
+++ b/src/modules/settings/manageKeys.ts
@@ -61,7 +61,16 @@ export async function manageKeysDialog() {
       false,
     )
     .addButton(getString("service-manageKeys-close"), "close")
-    .addButton(getString("service-manageKeys-save"), "save")
+    .addButton(getString("service-manageKeys-save"), "save", {
+      callback: () => {
+        const textarea = dialog.window?.document.querySelector(
+          `textarea[data-bind="secrets"]`,
+        ) as HTMLTextAreaElement | null;
+        if (textarea) {
+          dialogData.secrets = textarea.value;
+        }
+      },
+    })
     .open(getString("service-manageKeys-title"));
 
   if (dialogData.unloadLock && dialogData.unloadLock.promise) {

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -118,9 +118,9 @@ export function sanitizeTaskForLog(task: TranslateTask): TranslateTask {
   return {
     ...task,
     ...(task.secret ? { secret: maskAccessToken(task.secret) } : {}),
-    extraTasks: ((task.extraTasks ?? []).map((extraTask) =>
+    extraTasks: (task.extraTasks ?? []).map((extraTask) =>
       sanitizeTaskForLog(extraTask),
-    ) as TranslateTask["extraTasks"]),
+    ) as TranslateTask["extraTasks"],
   };
 }
 


### PR DESCRIPTION
Bug fix. Keys not saved due to previous PR #1418. 

**Secret management improvements:**

* Updated the logic in `onPrefsEvents` in `preferenceWindow.ts` so that `setServiceSecret` is only called if the trimmed secret value differs from the currently stored secret, preventing unnecessary updates. [[1]](diffhunk://#diff-950922a71b12736430d71fd7538010a95d4a228a4f4f2b5457ea9febf0319c48L409-R413) [[2]](diffhunk://#diff-950922a71b12736430d71fd7538010a95d4a228a4f4f2b5457ea9febf0319c48L469-R475)
* Enhanced the "Save" button in the `manageKeysDialog` in `manageKeys.ts` to ensure the latest value from the secrets textarea is saved to `dialogData.secrets` via a callback, improving reliability when saving user input.

**Code cleanup:**

* Removed redundant parentheses in the `sanitizeTaskForLog` function in `task.ts` for cleaner and more consistent code.