### PR TITLE
feat: render math in reader popup

### DIFF
--- a/src/elements/mathTextbox.ts
+++ b/src/elements/mathTextbox.ts
@@ -5,6 +5,7 @@ import { getPref } from "../utils/prefs";
 export class MathTextboxElement extends XULElementBase {
   private _textbox: XULTextBoxElement | null = null;
   private _overlay: HTMLElement | null = null;
+  private _overlayFrame: number | null = null;
   private _value: string = "";
 
   get content() {
@@ -78,7 +79,25 @@ export class MathTextboxElement extends XULElementBase {
   }
 
   private _showOverlay(): void {
-    if (this._overlay) this._overlay.remove();
+    const overlay = this._ensureOverlay();
+    overlay.style.display = "block";
+    this.toggleAttribute("overlay-visible", true);
+    this._scheduleOverlayRender();
+  }
+
+  private _hideOverlay(): void {
+    if (this._overlay) {
+      this._cancelOverlayRender();
+      this._overlay.innerHTML = "";
+      this._overlay.style.display = "none";
+    }
+    this.toggleAttribute("overlay-visible", false);
+  }
+
+  private _ensureOverlay(): HTMLElement {
+    if (this._overlay) {
+      return this._overlay;
+    }
     const HTML_NS = "http://www.w3.org/1999/xhtml";
     const doc = this.ownerDocument;
     const overlay = doc.createElementNS(
@@ -86,26 +105,53 @@ export class MathTextboxElement extends XULElementBase {
       "div",
     ) as unknown as HTMLElement;
     overlay.className = "math-overlay";
-    overlay.innerHTML = renderMathInText(doc, this._value);
+    overlay.style.display = "none";
     overlay.addEventListener("click", () => {
       this._hideOverlay();
       this._textbox?.focus();
     });
     this._overlay = overlay;
     this.appendChild(overlay);
-    this.toggleAttribute("overlay-visible", true);
+    return overlay;
   }
 
-  private _hideOverlay(): void {
+  private _scheduleOverlayRender(): void {
+    if (this._overlayFrame !== null) {
+      return;
+    }
+    const win = this.ownerDocument.defaultView;
+    const render = () => {
+      this._overlayFrame = null;
+      if (!this._overlay) {
+        return;
+      }
+      this._overlay.innerHTML = renderMathInText(
+        this.ownerDocument,
+        this._value,
+      );
+    };
+    if (win?.requestAnimationFrame) {
+      this._overlayFrame = win.requestAnimationFrame(render);
+      return;
+    }
+    render();
+  }
+
+  private _cancelOverlayRender(): void {
+    if (this._overlayFrame === null) {
+      return;
+    }
+    this.ownerDocument.defaultView?.cancelAnimationFrame?.(this._overlayFrame);
+    this._overlayFrame = null;
+  }
+
+  destroy(): void {
+    this._cancelOverlayRender();
     if (this._overlay) {
       this._overlay.remove();
       this._overlay = null;
     }
     this.toggleAttribute("overlay-visible", false);
-  }
-
-  destroy(): void {
-    this._hideOverlay();
     if (this._textbox) {
       this._textbox.removeEventListener("input", this._onInput);
       this._textbox.removeEventListener("focus", this._onFocus);

--- a/src/elements/mathTextbox.ts
+++ b/src/elements/mathTextbox.ts
@@ -1,5 +1,5 @@
 import { config } from "../../package.json";
-import { renderMathInText, containsMath } from "../utils/mathRenderer";
+import { renderMathInText, shouldRenderMath } from "../utils/mathRenderer";
 import { getPref } from "../utils/prefs";
 
 export class MathTextboxElement extends XULElementBase {
@@ -70,7 +70,7 @@ export class MathTextboxElement extends XULElementBase {
   private _updateOverlay(): void {
     // Respect user preference gate
     const enabled = (getPref("enableMathRendering") as boolean) === true;
-    if (!enabled || !this._value || !containsMath(this._value)) {
+    if (!shouldRenderMath(this._value, enabled)) {
       this._hideOverlay();
       return;
     }
@@ -80,12 +80,13 @@ export class MathTextboxElement extends XULElementBase {
   private _showOverlay(): void {
     if (this._overlay) this._overlay.remove();
     const HTML_NS = "http://www.w3.org/1999/xhtml";
-    const overlay = document.createElementNS(
+    const doc = this.ownerDocument;
+    const overlay = doc.createElementNS(
       HTML_NS,
       "div",
     ) as unknown as HTMLElement;
     overlay.className = "math-overlay";
-    overlay.innerHTML = renderMathInText(document, this._value);
+    overlay.innerHTML = renderMathInText(doc, this._value);
     overlay.addEventListener("click", () => {
       this._hideOverlay();
       this._textbox?.focus();

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -330,7 +330,6 @@ export function buildReaderPopup(
                 lineHeight: `${
                   Number(getPref("lineHeight")) * Number(getPref("fontSize"))
                 }px`,
-                maxHeight: "260px",
                 border: "none",
                 background: "var(--color-sidepane)",
                 borderRadius: "6px",

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -573,11 +573,12 @@ function updatePopupMathOverlay(
   overlay.style.direction = textarea.style.direction;
   overlay.style.display = state.overlayDisplay;
   textarea.style.visibility = state.textareaVisibility;
-  schedulePopupMathOverlayRender(overlay, textarea);
+  schedulePopupMathOverlayRender(overlay, container, textarea);
 }
 
 function schedulePopupMathOverlayRender(
   overlay: HTMLDivElement,
+  container: HTMLDivElement,
   textarea: HTMLTextAreaElement,
 ): void {
   if (popupMathOverlayFrames.has(overlay)) {
@@ -586,6 +587,7 @@ function schedulePopupMathOverlayRender(
   const render = () => {
     popupMathOverlayFrames.delete(overlay);
     overlay.innerHTML = renderMathInText(overlay.ownerDocument, textarea.value);
+    syncPopupRenderedTextContainer(container, textarea, overlay);
   };
   const win = overlay.ownerDocument.defaultView;
   if (win?.requestAnimationFrame) {
@@ -593,6 +595,48 @@ function schedulePopupMathOverlayRender(
     return;
   }
   render();
+}
+
+function syncPopupRenderedTextContainer(
+  container: HTMLDivElement,
+  textarea: HTMLTextAreaElement,
+  overlay: HTMLDivElement,
+): void {
+  if (getPref("keepPopupSize")) {
+    return;
+  }
+  const width = container.clientWidth || textarea.offsetWidth;
+  if (!width) {
+    return;
+  }
+
+  const measurement = overlay.cloneNode(false) as HTMLDivElement;
+  measurement.removeAttribute("id");
+  measurement.innerHTML = overlay.innerHTML;
+  measurement.style.position = "absolute";
+  measurement.style.inset = "auto";
+  measurement.style.left = "-100000px";
+  measurement.style.top = "0";
+  measurement.style.visibility = "hidden";
+  measurement.style.pointerEvents = "none";
+  measurement.style.display = "block";
+  measurement.style.boxSizing = overlay.style.boxSizing;
+  measurement.style.width = `${width}px`;
+  measurement.style.height = "auto";
+  measurement.style.maxHeight = "none";
+  measurement.style.overflow = "visible";
+
+  overlay.ownerDocument.body.appendChild(measurement);
+  const renderedHeight = Math.max(
+    30,
+    Math.ceil(measurement.scrollHeight),
+    Math.ceil(measurement.offsetHeight),
+  );
+  measurement.remove();
+
+  const height = `${renderedHeight}px`;
+  container.style.height = height;
+  textarea.style.height = height;
 }
 
 function cancelPopupMathOverlayRender(overlay: HTMLDivElement): void {

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -4,6 +4,10 @@ import { getString } from "../utils/locale";
 import { getPref, setPref } from "../utils/prefs";
 import { addTranslateTask, getLastTranslateTask } from "../utils/task";
 import { slice } from "../utils/str";
+import {
+  getMathOverlayState,
+  renderMathInText,
+} from "../utils/mathRenderer";
 
 export function updateReaderPopup() {
   const popup = addon.data.popup.currentPopup;
@@ -24,9 +28,15 @@ export function updateReaderPopup() {
   const translateButton = popup?.querySelector(
     `#${makeId("translate")}`,
   ) as HTMLDivElement;
+  const textContainer = popup?.querySelector(
+    `#${makeId("text-container")}`,
+  ) as HTMLDivElement;
   const textarea = popup?.querySelector(
     `#${makeId("text")}`,
   ) as HTMLTextAreaElement;
+  const mathOverlay = popup?.querySelector(
+    `#${makeId("math-overlay")}`,
+  ) as HTMLDivElement;
   const addToNoteButton = popup?.querySelector(
     `#${makeId("addtonote")}`,
   ) as HTMLDivElement;
@@ -42,7 +52,9 @@ export function updateReaderPopup() {
   if (!enablePopup) {
     updateHidden(audiobox, true);
     updateHidden(translateButton, true);
+    updateHidden(textContainer, true);
     updateHidden(textarea, true);
+    updateHidden(mathOverlay, true);
     updateHidden(addToNoteButton, true);
     return;
   }
@@ -104,6 +116,9 @@ export function updateReaderPopup() {
   textarea.style.lineHeight = `${
     Number(getPref("lineHeight")) * Number(getPref("fontSize"))
   }px`;
+  updatePopupSize(popup, textarea);
+  syncPopupTextContainer(textContainer, textarea);
+  updatePopupMathOverlay(mathOverlay, textContainer, textarea);
 
   const enableAddToNote = getPref("enableNote") as boolean;
   if (
@@ -112,8 +127,6 @@ export function updateReaderPopup() {
   ) {
     updateHidden(addToNoteButton, true);
   }
-
-  updatePopupSize(popup, textarea);
 }
 
 export function buildReaderPopup(
@@ -122,6 +135,7 @@ export function buildReaderPopup(
   const { reader, doc, append } = event;
   const annotation = event.params.annotation;
   const popup = doc.querySelector(".selection-popup") as HTMLDivElement;
+  ensurePopupMathStyles(doc);
   addon.data.popup.currentPopup = popup;
   popup.style.maxWidth = "none";
   popup.setAttribute(
@@ -191,87 +205,151 @@ export function buildReaderPopup(
           ignoreIfExists: true,
         },
         {
-          tag: "textarea",
-          id: makeId("text"),
-          attributes: {
-            rows: "3",
-            columns: "10",
-          },
+          tag: "div",
+          namespace: "html",
+          id: makeId("text-container"),
           classList: [
-            `${config.addonRef}-popup-textarea`,
+            `${config.addonRef}-popup-text-container`,
             `${config.addonRef}-readerpopup`,
           ],
           styles: {
-            fontSize: `${getPref("fontSize")}px`,
-            fontFamily: "inherit",
-            lineHeight: `${
-              Number(getPref("lineHeight")) * Number(getPref("fontSize"))
-            }px`,
+            position: "relative",
             width: keepSize ? `${getPref("popupWidth")}px` : "-moz-available",
-            // Minimum width to prevent the textarea from being smaller than the popup
             minWidth: "184px",
             height: `${Math.max(
               keepSize ? Number(getPref("popupHeight")) : 30,
             )}px`,
             marginInline: "2px",
-            border: "none",
-            background: "var(--color-sidepane)",
-            borderRadius: "6px",
-            padding: "5px",
           },
-          properties: {
-            onpointerup: (e: Event) => e.stopPropagation(),
-            ondragstart: (e: Event) => e.stopPropagation(),
-            spellcheck: false,
-            value: addon.data.translate.selectedText,
-          },
-          ignoreIfExists: true,
-          listeners: [
+          children: [
             {
-              type: "mousedown",
-              listener: (_ev) => {
-                _ev.target?.addEventListener(
-                  "mousemove",
-                  onTextAreaResize as (ev: Event) => void,
-                );
+              tag: "textarea",
+              id: makeId("text"),
+              attributes: {
+                rows: "3",
+                columns: "10",
               },
+              classList: [`${config.addonRef}-popup-textarea`],
+              styles: {
+                fontSize: `${getPref("fontSize")}px`,
+                fontFamily: "inherit",
+                lineHeight: `${
+                  Number(getPref("lineHeight")) * Number(getPref("fontSize"))
+                }px`,
+                width: keepSize
+                  ? `${getPref("popupWidth")}px`
+                  : "-moz-available",
+                // Minimum width to prevent the textarea from being smaller than the popup
+                minWidth: "184px",
+                height: `${Math.max(
+                  keepSize ? Number(getPref("popupHeight")) : 30,
+                )}px`,
+                border: "none",
+                background: "var(--color-sidepane)",
+                borderRadius: "6px",
+                padding: "5px",
+              },
+              properties: {
+                onpointerup: (e: Event) => e.stopPropagation(),
+                ondragstart: (e: Event) => e.stopPropagation(),
+                spellcheck: false,
+                value: addon.data.translate.selectedText,
+              },
+              ignoreIfExists: true,
+              listeners: [
+                {
+                  type: "mousedown",
+                  listener: (_ev) => {
+                    _ev.target?.addEventListener(
+                      "mousemove",
+                      onTextAreaResize as (ev: Event) => void,
+                    );
+                  },
+                },
+                {
+                  type: "mouseup",
+                  listener: (_ev) => {
+                    _ev.target?.removeEventListener(
+                      "mousemove",
+                      onTextAreaResize as (ev: Event) => void,
+                    );
+                  },
+                },
+                {
+                  type: "keydown",
+                  listener: onTextAreaCopy as (ev: Event) => void,
+                },
+                {
+                  type: "dblclick",
+                  listener: (_ev) => {
+                    const textarea = popup.querySelector(
+                      `#${makeId("text")}`,
+                    ) as HTMLTextAreaElement;
+                    textarea.selectionStart = 0;
+                    textarea.selectionEnd = textarea.value.length;
+                    const text = textarea.value.slice(
+                      textarea.selectionStart,
+                      textarea.selectionEnd,
+                    );
+                    new ztoolkit.Clipboard().addText(text, "text/plain").copy();
+                    new ztoolkit.ProgressWindow("Copied to Clipboard")
+                      .createLine({
+                        text: slice(text, 50),
+                        progress: 100,
+                        type: "default",
+                      })
+                      .show();
+                  },
+                },
+              ],
             },
             {
-              type: "mouseup",
-              listener: (_ev) => {
-                _ev.target?.removeEventListener(
-                  "mousemove",
-                  onTextAreaResize as (ev: Event) => void,
-                );
+              tag: "div",
+              namespace: "html",
+              id: makeId("math-overlay"),
+              classList: [`${config.addonRef}-popup-math-overlay`],
+              styles: {
+                display: "none",
+                position: "absolute",
+                inset: "0",
+                boxSizing: "border-box",
+                fontSize: `${getPref("fontSize")}px`,
+                fontFamily: "inherit",
+                lineHeight: `${
+                  Number(getPref("lineHeight")) * Number(getPref("fontSize"))
+                }px`,
+                maxHeight: "260px",
+                border: "none",
+                background: "var(--color-sidepane)",
+                borderRadius: "6px",
+                padding: "5px",
+                overflow: "auto",
+                textAlign: "start",
               },
-            },
-            {
-              type: "keydown",
-              listener: onTextAreaCopy as (ev: Event) => void,
-            },
-            {
-              type: "dblclick",
-              listener: (_ev) => {
-                const textarea = popup.querySelector(
-                  `#${makeId("text")}`,
-                ) as HTMLTextAreaElement;
-                textarea.selectionStart = 0;
-                textarea.selectionEnd = textarea.value.length;
-                const text = textarea.value.slice(
-                  textarea.selectionStart,
-                  textarea.selectionEnd,
-                );
-                new ztoolkit.Clipboard().addText(text, "text/plain").copy();
-                new ztoolkit.ProgressWindow("Copied to Clipboard")
-                  .createLine({
-                    text: slice(text, 50),
-                    progress: 100,
-                    type: "default",
-                  })
-                  .show();
+              properties: {
+                onpointerup: (e: Event) => e.stopPropagation(),
+                ondragstart: (e: Event) => e.stopPropagation(),
               },
+              listeners: [
+                {
+                  type: "click",
+                  listener: () => {
+                    const overlay = popup.querySelector(
+                      `#${makeId("math-overlay")}`,
+                    ) as HTMLDivElement;
+                    const textarea = popup.querySelector(
+                      `#${makeId("text")}`,
+                    ) as HTMLTextAreaElement;
+                    overlay.style.display = "none";
+                    textarea.style.removeProperty("visibility");
+                    textarea.focus();
+                  },
+                },
+              ],
+              ignoreIfExists: true,
             },
           ],
+          ignoreIfExists: true,
         },
         {
           tag: "button",
@@ -411,4 +489,51 @@ function updatePopupSize(
   }
   // Update height
   textarea.style.height = `${textHeight + 3}px`;
+}
+
+function syncPopupTextContainer(
+  container: HTMLDivElement,
+  textarea: HTMLTextAreaElement,
+): void {
+  container.hidden = textarea.hidden;
+  container.style.width = textarea.style.width;
+  container.style.height = textarea.style.height;
+}
+
+function ensurePopupMathStyles(doc: Document): void {
+  const id = `${config.addonRef}-popup-math-styles`;
+  if (doc.getElementById(id)) {
+    return;
+  }
+  const link = doc.createElement("link");
+  link.id = id;
+  link.rel = "stylesheet";
+  link.href = `chrome://${config.addonRef}/content/styles/katex.min.css`;
+  doc.head?.append(link);
+}
+
+function updatePopupMathOverlay(
+  overlay: HTMLDivElement,
+  container: HTMLDivElement,
+  textarea: HTMLTextAreaElement,
+): void {
+  const enabled = (getPref("enableMathRendering") as boolean) === true;
+  const state = getMathOverlayState({
+    text: textarea.value,
+    enabled,
+    hiddenByPreference: container.hidden,
+  });
+  if (state.overlayDisplay === "none") {
+    overlay.innerHTML = "";
+    overlay.style.display = state.overlayDisplay;
+    textarea.style.removeProperty("visibility");
+    return;
+  }
+
+  overlay.innerHTML = renderMathInText(overlay.ownerDocument, textarea.value);
+  overlay.style.fontSize = textarea.style.fontSize;
+  overlay.style.lineHeight = textarea.style.lineHeight;
+  overlay.style.direction = textarea.style.direction;
+  overlay.style.display = state.overlayDisplay;
+  textarea.style.visibility = state.textareaVisibility;
 }

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -4,12 +4,10 @@ import { getString } from "../utils/locale";
 import { getPref, setPref } from "../utils/prefs";
 import { addTranslateTask, getLastTranslateTask } from "../utils/task";
 import { slice } from "../utils/str";
-import {
-  getMathOverlayState,
-  renderMathInText,
-} from "../utils/mathRenderer";
+import { getMathOverlayState, renderMathInText } from "../utils/mathRenderer";
 
 const popupMathOverlayFrames = new WeakMap<HTMLDivElement, number>();
+const popupTaskMaxWidths = new Map<string, number>();
 
 export function updateReaderPopup() {
   const popup = addon.data.popup.currentPopup;
@@ -120,7 +118,11 @@ export function updateReaderPopup() {
   textarea.style.lineHeight = `${
     Number(getPref("lineHeight")) * Number(getPref("fontSize"))
   }px`;
-  updatePopupSize(popup, textarea);
+  updatePopupSize(
+    popup,
+    textarea,
+    getPopupWidthTrackingTaskId(task.id, task.result),
+  );
   syncPopupTextContainer(textContainer, textarea);
   updatePopupMathOverlay(mathOverlay, textContainer, textarea);
 
@@ -467,6 +469,7 @@ function getOnTextAreaCopy(selectionMenu: HTMLElement, targetId: string) {
 function updatePopupSize(
   selectionMenu: HTMLDivElement,
   textarea: HTMLTextAreaElement,
+  taskId?: string,
   resetSize: boolean = true,
 ): void {
   const keepSize = getPref("keepPopupSize") as boolean;
@@ -489,11 +492,35 @@ function updatePopupSize(
   ) {
     // Update width
     textarea.style.width = `${newWidth}px`;
-    updatePopupSize(selectionMenu, textarea, false);
+    updatePopupSize(selectionMenu, textarea, taskId, false);
     return;
+  }
+  if (taskId) {
+    textarea.style.width = `${getTaskScopedPopupWidth(
+      taskId,
+      textarea.offsetWidth,
+    )}px`;
   }
   // Update height
   textarea.style.height = `${textHeight + 3}px`;
+}
+
+function getTaskScopedPopupWidth(taskId: string, width: number): number {
+  const previousWidth = popupTaskMaxWidths.get(taskId) ?? 0;
+  const nextWidth = Math.max(previousWidth, width);
+  popupTaskMaxWidths.set(taskId, nextWidth);
+  return nextWidth;
+}
+
+function getPopupWidthTrackingTaskId(
+  taskId: string,
+  result: string,
+): string | undefined {
+  const trimmedResult = result.trim();
+  if (!trimmedResult || trimmedResult === getString("status-translating")) {
+    return undefined;
+  }
+  return taskId;
 }
 
 function syncPopupTextContainer(

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -9,6 +9,8 @@ import {
   renderMathInText,
 } from "../utils/mathRenderer";
 
+const popupMathOverlayFrames = new WeakMap<HTMLDivElement, number>();
+
 export function updateReaderPopup() {
   const popup = addon.data.popup.currentPopup;
   if (!popup) {
@@ -50,6 +52,8 @@ export function updateReaderPopup() {
   };
 
   if (!enablePopup) {
+    cancelPopupMathOverlayRender(mathOverlay);
+    mathOverlay.innerHTML = "";
     updateHidden(audiobox, true);
     updateHidden(translateButton, true);
     updateHidden(textContainer, true);
@@ -340,6 +344,7 @@ export function buildReaderPopup(
                     const textarea = popup.querySelector(
                       `#${makeId("text")}`,
                     ) as HTMLTextAreaElement;
+                    cancelPopupMathOverlayRender(overlay);
                     overlay.style.display = "none";
                     textarea.style.removeProperty("visibility");
                     textarea.focus();
@@ -524,16 +529,45 @@ function updatePopupMathOverlay(
     hiddenByPreference: container.hidden,
   });
   if (state.overlayDisplay === "none") {
+    cancelPopupMathOverlayRender(overlay);
     overlay.innerHTML = "";
     overlay.style.display = state.overlayDisplay;
     textarea.style.removeProperty("visibility");
     return;
   }
 
-  overlay.innerHTML = renderMathInText(overlay.ownerDocument, textarea.value);
   overlay.style.fontSize = textarea.style.fontSize;
   overlay.style.lineHeight = textarea.style.lineHeight;
   overlay.style.direction = textarea.style.direction;
   overlay.style.display = state.overlayDisplay;
   textarea.style.visibility = state.textareaVisibility;
+  schedulePopupMathOverlayRender(overlay, textarea);
+}
+
+function schedulePopupMathOverlayRender(
+  overlay: HTMLDivElement,
+  textarea: HTMLTextAreaElement,
+): void {
+  if (popupMathOverlayFrames.has(overlay)) {
+    return;
+  }
+  const render = () => {
+    popupMathOverlayFrames.delete(overlay);
+    overlay.innerHTML = renderMathInText(overlay.ownerDocument, textarea.value);
+  };
+  const win = overlay.ownerDocument.defaultView;
+  if (win?.requestAnimationFrame) {
+    popupMathOverlayFrames.set(overlay, win.requestAnimationFrame(render));
+    return;
+  }
+  render();
+}
+
+function cancelPopupMathOverlayRender(overlay: HTMLDivElement): void {
+  const frame = popupMathOverlayFrames.get(overlay);
+  if (typeof frame === "undefined") {
+    return;
+  }
+  overlay.ownerDocument.defaultView?.cancelAnimationFrame?.(frame);
+  popupMathOverlayFrames.delete(overlay);
 }

--- a/src/modules/popup.ts
+++ b/src/modules/popup.ts
@@ -60,6 +60,12 @@ export function updateReaderPopup() {
     updateHidden(addToNoteButton, true);
     return;
   }
+  updateHidden(audiobox, false);
+  updateHidden(translateButton, false);
+  updateHidden(textContainer, false);
+  updateHidden(textarea, false);
+  updateHidden(mathOverlay, false);
+  updateHidden(addToNoteButton, false);
   const task = getLastTranslateTask({ type: "text" });
   if (!task) {
     return;

--- a/src/utils/mathRenderer.ts
+++ b/src/utils/mathRenderer.ts
@@ -18,6 +18,25 @@ export function containsMath(text: string): boolean {
   return TEST_REGEX.test(text);
 }
 
+export function shouldRenderMath(text: string, enabled: boolean): boolean {
+  return enabled && containsMath(text);
+}
+
+export function getMathOverlayState(options: {
+  text: string;
+  enabled: boolean;
+  hiddenByPreference: boolean;
+}): {
+  overlayDisplay: "block" | "none";
+  textareaVisibility: "hidden" | "";
+} {
+  const visible = shouldRenderMath(options.text, options.enabled);
+  return {
+    overlayDisplay: visible && !options.hiddenByPreference ? "block" : "none",
+    textareaVisibility: visible && !options.hiddenByPreference ? "hidden" : "",
+  };
+}
+
 export function escapeHtml(doc: Document, text: string): string {
   const div = doc.createElement("div");
   div.textContent = text;

--- a/src/utils/mathRenderer.ts
+++ b/src/utils/mathRenderer.ts
@@ -1,12 +1,12 @@
 import katex from "katex";
 
-// Unified, robust math rendering helpers
-// Avoid lookbehind for broader engine compatibility by capturing a non-escape prefix
-// Order: display (“$$ … $$”, "\\[ … \"] first), then inline “$ … $” (no newline), then "\\( … \")
+// Unified, stream-safe math rendering helpers.
+// Avoid lookbehind for broader engine compatibility by capturing a non-escape prefix.
+// Only closed delimiters are rendered; unmatched stream fragments remain escaped text.
 const MATH_REGEX =
   /(^|[^\\])\$\$([\s\S]*?)\$\$|\\\[([\s\S]*?)\\\]|(^|[^\\])\$(?!\$)([^\n]*?)\$(?!\$)|\\\(([\s\S]*?)\\\)/g;
 const DEFAULT_KATEX_OPTIONS = {
-  throwOnError: false,
+  throwOnError: true,
   errorColor: "#cc0000",
   strict: false,
 } as const;

--- a/src/utils/mathRenderer.ts
+++ b/src/utils/mathRenderer.ts
@@ -10,6 +10,8 @@ const DEFAULT_KATEX_OPTIONS = {
   errorColor: "#cc0000",
   strict: false,
 } as const;
+const CONSECUTIVE_BR_REGEX = /(?:<br\s*\/?><\/br>|<br\s*\/?>\s*){2,}/gi;
+const HTML_BREAK = "<br />";
 
 export function containsMath(text: string): boolean {
   if (!text) return false;
@@ -40,7 +42,11 @@ export function getMathOverlayState(options: {
 export function escapeHtml(doc: Document, text: string): string {
   const div = doc.createElement("div");
   div.textContent = text;
-  return div.innerHTML.replace(/\n/g, "<br></br>");
+  return div.innerHTML.replace(/\n+/g, HTML_BREAK);
+}
+
+function collapseConsecutiveBreaks(html: string): string {
+  return html.replace(CONSECUTIVE_BR_REGEX, HTML_BREAK);
 }
 
 export function renderMathInText(doc: Document, text: string): string {
@@ -62,12 +68,6 @@ export function renderMathInText(doc: Document, text: string): string {
       inlineParen,
     ] = match;
 
-    const prefixLen = dispPrefix || inlinePrefix ? 1 : 0;
-    const plainEnd = match.index + prefixLen;
-    if (plainEnd > lastIndex) {
-      result += escapeHtml(doc, text.slice(lastIndex, plainEnd));
-    }
-
     let displayMode = false;
     let latex = "";
     if (typeof dispDollar !== "undefined") {
@@ -84,6 +84,16 @@ export function renderMathInText(doc: Document, text: string): string {
       latex = String(inlineParen).trim();
     }
 
+    const prefixLen = dispPrefix || inlinePrefix ? 1 : 0;
+    const plainEnd = match.index + prefixLen;
+    if (plainEnd > lastIndex) {
+      const plainText = text.slice(lastIndex, plainEnd);
+      result += escapeHtml(
+        doc,
+        displayMode ? plainText.replace(/\n$/, "") : plainText,
+      );
+    }
+
     try {
       const rendered = katex.renderToString(latex, {
         ...DEFAULT_KATEX_OPTIONS,
@@ -95,13 +105,18 @@ export function renderMathInText(doc: Document, text: string): string {
     }
 
     lastIndex = match.index + full.length;
+    if (displayMode) {
+      while (text[lastIndex] === "\n") {
+        lastIndex += 1;
+      }
+    }
   }
 
   if (lastIndex < text.length) {
     result += escapeHtml(doc, text.slice(lastIndex));
   }
 
-  return result;
+  return collapseConsecutiveBreaks(result);
 }
 
 export function renderMathInElement(element: HTMLElement, text: string): void {


### PR DESCRIPTION
## Summary

This PR adds LaTeX formula rendering support to the Reader selection popup, addressing https://github.com/windingwind/zotero-pdf-translate/issues/1076#issuecomment-4285743765.

## Changes

- Added KaTeX rendering for translated text shown in the Reader popup.
- Supports existing LaTeX delimiters: `$...$`, `$$...$$`, `\(...\)`, and `\[...\]`.
- Makes popup formula rendering stream-safe:
  - incomplete formulas are shown as plain escaped text while streaming
  - formulas render automatically once the closing delimiter arrives
  - invalid KaTeX content falls back to escaped source text
- Reuses and throttles popup math overlay updates during streaming to reduce unnecessary re-rendering.
- Keeps Reader popup width stable during streaming so the popup can grow but does not repeatedly shrink.

## Known Issues

- ~The Reader popup height may not fit the translated text height exactly.~(fixed in latest commits)

<img width="406" height="386" alt="image" src="https://github.com/user-attachments/assets/f1590c0b-3771-4125-a947-60db58947389" />
