### PR TITLE
Adding word service - dictionary gramota.ru

### DIFF
--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -41,6 +41,7 @@ service-collinsdict=Collins Dict(en→zh)🔊
 service-youdaodict=Youdao Dict(en→zh)🔊
 service-freedictionaryapi=FreeDictionaryAPI(en→en)
 service-webliodict=Weblio Dict(en→ja)
+service-gramotadict=Gramota.ru(ru)
 service-errorPrefix=[Request Error]
     Service not available, invalid secret, or request too fast.
     Use another translation service or post the issue here: 

--- a/addon/locale/it-IT/addon.ftl
+++ b/addon/locale/it-IT/addon.ftl
@@ -41,6 +41,7 @@ service-collinsdict=Collins Dict(en→zh)🔊
 service-youdaodict=Youdao Dict(en→zh)🔊
 service-freedictionaryapi=FreeDictionaryAPI(en→en)
 service-webliodict=Weblio Dict(en→ja)
+service-gramotadict=Gramota.ru(ru)
 service-errorPrefix=[Errore nella richiesta]
     Servizio di traduzione non disponibile, segreto non valido, o richiesta troppo rapida.
     Si prega di usare un altro servizio di traduzione o di segnalare il problema qui: 

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -41,6 +41,7 @@ service-collinsdict=科林斯词典(en→zh)🔊
 service-youdaodict=有道词典(en→zh)🔊
 service-freedictionaryapi=FreeDictionaryAPI(en→en)
 service-webliodict=Weblio Dict(en→ja)
+service-gramotadict=Gramota.ru(ru)
 service-errorPrefix=[请求错误]
     此翻译服务不可用，可能是密钥错误，也可能是请求过快。
     可以尝试其他翻译服务，或者来此查看相关回答：

--- a/src/modules/services/gramotadict.ts
+++ b/src/modules/services/gramotadict.ts
@@ -1,0 +1,67 @@
+import { TranslateService } from "./base";
+
+const translate: TranslateService["translate"] = async function (data) {
+  const word = data.raw.trim();
+
+  Zotero.debug("[GramotaDict] looking up: " + word);
+
+  const xhr = await Zotero.HTTP.request(
+    "GET",
+    `https://gramota.ru/poisk?query=${encodeURIComponent(word)}&mode=all`,
+    { responseType: "text" },
+  );
+
+  Zotero.debug("[GramotaDict] response status: " + xhr?.status);
+
+  if (xhr?.status !== 200) {
+    throw `Request error: ${xhr?.status}`;
+  }
+
+  const doc = new DOMParser().parseFromString(xhr.response, "text/html");
+
+  const metaWidget = doc.querySelector(".meta-dictionary-widget");
+  Zotero.debug("[GramotaDict] meta-widget found: " + !!metaWidget);
+
+  if (!metaWidget) {
+    throw "Слово не найдено в словарях";
+  }
+
+  const title = metaWidget.querySelector(".title")?.textContent?.trim() || word;
+
+  const crHlEl = metaWidget.querySelector(".hl-line .cr-hl");
+  const crHlText = crHlEl?.textContent?.trim() || "";
+
+  const definitions: string[] = [];
+  const items = metaWidget.querySelectorAll<Element>(
+    ".numbered .order-list .item",
+  );
+  items.forEach((item) => {
+    const number = item.querySelector(".number")?.textContent?.trim() || "";
+    const content = item.querySelector(".content");
+    if (content) {
+      const clone = content.cloneNode(true) as Element;
+      clone.querySelectorAll(".grey-badge").forEach((badge) => {
+        const text = badge.textContent?.trim() || "";
+        badge.replaceWith(`(${text})`);
+      });
+      const text = clone.textContent?.trim()?.replace(/\s+/g, " ") || "";
+      if (text) {
+        definitions.push(number ? `${number} ${text}` : text);
+      }
+    }
+  });
+
+  let result = title;
+  if (crHlText) result += `\n${crHlText}`;
+  if (definitions.length > 0) result += `\n\n${definitions.join("\n")}`;
+
+  Zotero.debug("[GramotaDict] result: " + result);
+
+  data.result = result;
+};
+
+export const GramotaDict: TranslateService = {
+  id: "gramotadict",
+  type: "word",
+  translate,
+};

--- a/src/modules/services/index.ts
+++ b/src/modules/services/index.ts
@@ -27,6 +27,7 @@ import { Gemini } from "./gemini";
 import { Google, GoogleAPI } from "./google";
 import { Haici } from "./haici";
 import { HaiciDict } from "./haicidict";
+import { GramotaDict } from "./gramotadict";
 import { Huoshan } from "./huoshan";
 import { HuoshanWeb } from "./huoshanweb";
 import { LibreTranslate } from "./libretranslate";
@@ -64,6 +65,7 @@ const register: TranslateService[] = [
   DeepLX,
   FreeDictionaryAPI,
   Gemini,
+  GramotaDict,
   Google,
   GoogleAPI,
   ChatGPT,

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -168,6 +168,7 @@ export type FluentMessageId =
   | 'service-gemini-dialog-stream'
   | 'service-google'
   | 'service-googleapi'
+  | 'service-gramotadict'
   | 'service-haici'
   | 'service-haicidict'
   | 'service-huoshan'


### PR DESCRIPTION
Gramota.ru is the most popular Russian language website in Russia.

Unfortunately they don't provide any sort of API, there is only a GET-search with HTML-output that needs to be parsed.

This PR provides the Gramota.ru **word service**. It's simple and quite opinionated. 

Specifically:

- it limits itself to searching through dictionaries only;
- and even then - it doesn't query full articles from the dictionaries;
- it parses only the key part of the output dismissing the rest of the page.

A better support ought to be done in the future.
