### PR TITLE
fix: clarify NiuTrans insufficient balance error

### DIFF
--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -49,6 +49,14 @@ service-errorPrefix=[Request Error]
     
     The message below is not Zotero or the Translate plugin, but from
 
+service-niutranspro-error-insufficient-balance=
+    The current NiuTrans points balance is insufficient, so the translation request cannot be completed.
+    Please purchase points from the NiuTrans recharge center and try again.
+
+    NiuTrans recharge center: https://niutrans.com/price
+
+    Error code: { $code } { $message }
+
 service-dialog-config=Config
 service-dialog-title={ $service } Config
 service-dialog-save=Save

--- a/addon/locale/it-IT/addon.ftl
+++ b/addon/locale/it-IT/addon.ftl
@@ -49,6 +49,14 @@ service-errorPrefix=[Errore nella richiesta]
     
     Il messaggio seguente non è di Zotero o dell'estensione Translate ma proviene da
 
+service-niutranspro-error-insufficient-balance=
+    Il saldo punti NiuTrans non è sufficiente per completare la richiesta di traduzione.
+    Acquista punti nel centro ricariche NiuTrans e riprova.
+
+    Centro ricariche NiuTrans: https://niutrans.com/price
+
+    Codice errore: { $code } { $message }
+
 service-dialog-config=Config
 service-dialog-title={ $service } Config
 service-dialog-save=Save

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -49,6 +49,14 @@ service-errorPrefix=[请求错误]
     
     请注意，这些错误与 Zotero 和本翻译插件无关，由该翻译服务引起：
 
+service-niutranspro-error-insufficient-balance=
+    当前小牛翻译积分不足，无法完成翻译请求。
+    请前往小牛翻译充值中心购买积分后重试。
+
+    小牛翻译充值中心：https://niutrans.com/price
+
+    错误代码：{ $code } { $message }
+
 service-dialog-config=配置
 service-dialog-title={ $service } 配置
 service-dialog-save=保存

--- a/src/modules/services/niutrans.ts
+++ b/src/modules/services/niutrans.ts
@@ -4,6 +4,7 @@ import {
   getString,
   ServiceSettingsDialog,
   setServiceSecret,
+  TranslateError,
 } from "../../utils";
 import { getPref, setPref } from "../../utils/prefs";
 import { TranslateService } from "./base";
@@ -53,6 +54,16 @@ const translate = <TranslateService["translate"]>async function (data) {
   }
 
   if (xhr.response.code !== 200) {
+    if (xhr.response.code === 13001) {
+      throw new TranslateError(
+        getString("service-niutranspro-error-insufficient-balance", {
+          args: {
+            code: xhr.response.code,
+            message: xhr.response.msg,
+          },
+        }),
+      );
+    }
     throw `Service error: ${xhr.response.code}:${xhr.response.msg}`;
   }
   if (endpoint.includes("neu.edu.cn")) {

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -96,6 +96,8 @@ export type TranslateTaskProcessor = (
   data: Required<TranslateTask>,
 ) => Promise<void> | void;
 
+export class TranslateError extends Error {}
+
 function maskAccessToken(token: string): string {
   if (!token) return token;
 
@@ -160,7 +162,11 @@ export class TranslateTaskRunner {
       await this.processor(data as Required<TranslateTask>);
       data.status = "success";
     } catch (e) {
-      data.result = this.makeErrorInfo(data.service, String(e));
+      if (e instanceof TranslateError) {
+        data.result = e.message;
+      } else {
+        data.result = this.makeErrorInfo(data.service, String(e));
+      }
       data.status = "fail";
     }
     data.processed = true;

--- a/typings/i10n.d.ts
+++ b/typings/i10n.d.ts
@@ -197,6 +197,7 @@ export type FluentMessageId =
   | 'service-niutranspro-dialog-tip1'
   | 'service-niutranspro-dialog-tip2'
   | 'service-niutranspro-dialog-username'
+  | 'service-niutranspro-error-insufficient-balance'
   | 'service-nllb'
   | 'service-nllb-dialog-apiendpoint'
   | 'service-nllb-dialog-apilabel'


### PR DESCRIPTION
## Summary

  - Detect NiuTrans insufficient balance responses (`13001` or `Balance is
  insufficient`).
  - Show a dedicated localized message with the NiuTrans recharge URL and
  original error details.
  - Allow translation services to provide a user-facing error message without
  hard-coding service-specific branches in the shared task runner.
  - Keep other translation service errors on the existing generic error path.