### PR TITLE
fix(cnki): read token from response.data instead of response.token

### DIFF
--- a/src/modules/services/cnki.ts
+++ b/src/modules/services/cnki.ts
@@ -137,7 +137,7 @@ export async function getToken(forceRefresh: boolean = false) {
       300,
     );
     if (xhr && xhr.response && xhr.response.code === 200) {
-      token = xhr.response.token;
+      token = xhr.response.data;
       setPref(
         "cnkiToken",
         JSON.stringify({


### PR DESCRIPTION
## Problem

The CNKI token endpoint `https://dict.cnki.net/fyzs-front-api/getToken` returns:

```json
{"msg":"","code":200,"data":"<uuid>"}
```

There is no `token` field, but `getToken()` in `src/modules/services/cnki.ts` did:

```ts
token = xhr.response.token;      // undefined!
setPref("cnkiToken", JSON.stringify({ t: ..., token: xhr.response.data }));  // correct value cached
```

## Consequence

- Within 300s after a previous fetch, the cached (correct) token is returned and CNKI translation works.
- Once the cache expires, the refresh path returns `undefined`, so `translate/literaltranslation` is called with header `Token: undefined` and fails (401) whenever CNKI enforces token validation — i.e. CNKI translation breaks ~5 minutes after startup.

## Fix

Return the same field that is already being cached:

```diff
-      token = xhr.response.token;
+      token = xhr.response.data;
```

Verified against the live API: `getToken` responds with `{msg, code, data}`; `literaltranslation` accepts the token taken from `data`.