### PR TITLE
fix(youdao): migrate to web demo API as fanyi.youdao.com/translate is dead

### DIFF
--- a/src/modules/services/youdao.ts
+++ b/src/modules/services/youdao.ts
@@ -1,29 +1,46 @@
 import { TranslateService } from "./base";
 
-const translate: TranslateService["translate"] = async function (data) {
-  const param = `${data.langfrom.toUpperCase().replace("-", "_")}2${data.langto
-    .toUpperCase()
-    .replace("-", "_")}`;
+// Lang code map for the Youdao web demo API (https://fanyi.youdao.com, backed
+// by https://aidemo.youdao.com/trans). The old open endpoint
+// http://fanyi.youdao.com/translate now redirects (302) to an error page.
+const langMap: Record<string, string> = {
+  "zh-CN": "zh-CHS",
+  "zh-TW": "zh-CHT",
+  "zh-HK": "zh-CHT",
+  "zh-MO": "zh-CHT",
+};
 
+const mapLang = (lang: string) => langMap[lang] || lang.split("-")[0];
+
+const translate: TranslateService["translate"] = async function (data) {
+  const params = new URLSearchParams({
+    from: mapLang(data.langfrom),
+    to: mapLang(data.langto),
+    q: data.raw,
+  });
   const xhr = await Zotero.HTTP.request(
-    "GET",
-    `http://fanyi.youdao.com/translate?&doctype=json&type=${param}&i=${encodeURIComponent(
-      data.raw,
-    )}`,
-    { responseType: "json" },
+    "POST",
+    "https://aidemo.youdao.com/trans",
+    {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: params.toString(),
+      responseType: "json",
+    },
   );
   if (xhr?.status !== 200) {
     throw `Request error: ${xhr?.status}`;
   }
-
-  const res = xhr.response.translateResult;
-  let tgt = "";
-  for (const i in res) {
-    for (const j in res[i]) {
-      tgt += res[i][j].tgt;
-    }
+  const res = xhr.response;
+  if (res.errorCode && res.errorCode !== "0") {
+    throw `Youdao error code: ${res.errorCode}`;
   }
-  data.result = tgt;
+  const translation = res.translation as string[] | undefined;
+  if (!translation || translation.length === 0) {
+    throw "No result found error";
+  }
+  data.result = translation.join("\n");
 };
 
 export const Youdao: TranslateService = {


### PR DESCRIPTION
## Problem

The Youdao (no-key) service is broken: the old endpoint

`http://fanyi.youdao.com/translate?&doctype=json&type=EN2zh_CN&i=...`

now answers `302` → `https://fanyi.youdao.com/error.html` (the legacy open API has been retired), so every translation fails.

## Fix

Migrate to the endpoint used by Youdao's own web page (`fanyi.youdao.com`): `POST https://aidemo.youdao.com/trans` — still **no key required**.

- Language codes differ: `zh-CN → zh-CHS`, `zh-TW/HK/MO → zh-CHT`; other languages use the base code (`en-US → en`)
- Response shape: `{ errorCode: "0", translation: ["…"], … }`

## Verification (live API)

```
POST from=en&to=zh-CHS&q=The cislunar region is increasingly important.
-> { errorCode: '0', translation: ['顺月区域越来越重要。'], ... }

POST from=auto&to=zh-CHS&q=stable graveyard orbits
-> { errorCode: '0', translation: ['稳定的墓地轨道'], ... }

POST to=zh-CN (unmapped code)
-> { errorCode: '102' }   // surfaced as a service error
```