### PR TITLE
fix(huoshanweb): use trailing-slash endpoint to avoid 307 redirect

### DIFF
--- a/src/modules/services/huoshanweb.ts
+++ b/src/modules/services/huoshanweb.ts
@@ -9,7 +9,7 @@ export const HuoshanWeb: TranslateService = {
     const { raw: text } = data;
     const from = (data.langfrom || "").split("-")[0];
     const to = (data.langto || "").split("-")[0];
-    const URL = "https://translate.volcengine.com/crx/translate/v1";
+    const URL = "https://translate.volcengine.com/crx/translate/v1/";
     const body = {
       source_language: from,
       target_language: to,


### PR DESCRIPTION
## Problem

`Huoshan Web` (no-key) POSTs to

`https://translate.volcengine.com/crx/translate/v1`

(without trailing slash). The server now answers **307 Temporary Redirect** with `Location: /crx/translate/v1/`. The redirect response carries **no CORS headers**, and any request path that doesn't follow the 307 ends up with an empty/failed response — the service appears dead.

## Fix

Call the canonical URL with the trailing slash:

```diff
-const URL = "https://translate.volcengine.com/crx/translate/v1";
+const URL = "https://translate.volcengine.com/crx/translate/v1/";
```

## Verification (live API)

```
POST /crx/translate/v1  (no slash) -> 307 + Location: /crx/translate/v1/, no CORS headers
POST /crx/translate/v1/ (slash)    -> 200 { "translation": "你好世界", ... } + Access-Control-Allow-Origin: *
```